### PR TITLE
resources: Add gfx902 targets to GPU applications

### DIFF
--- a/src/gpu/DNNMark/generate_cachefiles.py
+++ b/src/gpu/DNNMark/generate_cachefiles.py
@@ -20,7 +20,7 @@ def parseArgs():
     parser.add_argument('--num-cus', default=4, type=int,
                         help='Number of CUs in simulated GPU')
     parser.add_argument('--gfx-version', default='gfx801',
-                        choices=['gfx801', 'gfx803', 'gfx900'],
+                        choices=['gfx801', 'gfx803', 'gfx900', 'gfx902'],
                         help='gfx version of simulated GPU')
 
     return parser.parse_args()
@@ -59,6 +59,8 @@ def insertFiles(con, options):
                   'gfx803': '-Wno-everything -Xclang '
                             '-target-feature -Xclang +code-object-v3',
                   'gfx900': '-Wno-everything -Xclang '
+                            '-target-feature -Xclang +code-object-v3',
+                  'gfx902': '-Wno-everything -Xclang '
                             '-target-feature -Xclang +code-object-v3'}
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/gpu/heterosync/Makefile
+++ b/src/gpu/heterosync/Makefile
@@ -9,7 +9,7 @@ BIN_DIR := bin
 all: release
 
 release: $(SRC) | $(BIN_DIR)
-	$(HIP_PATH)/bin/hipcc -DGFX9 --amdgpu-target=gfx900 $(SRC) -o $(BIN_DIR)/$(EXECUTABLE)
+	$(HIP_PATH)/bin/hipcc -DGFX9 --amdgpu-target=gfx900,gfx902 $(SRC) -o $(BIN_DIR)/$(EXECUTABLE)
 
 # gfx8 has a different number of bits it uses for sleeps, so compile accordingly
 release-gfx8: $(SRC) | $(BIN_DIR)

--- a/src/gpu/hip-samples/Makefile
+++ b/src/gpu/hip-samples/Makefile
@@ -12,7 +12,7 @@ EXECUTABLES := $(basename $(notdir $(SOURCES)))
 all: $(EXECUTABLES)
 
 $(EXECUTABLES): %: $(SRC_DIR)/%.cpp | $(BIN_DIR)
-	$(HIPCC) --amdgpu-target=gfx801,gfx803,gfx900 $< -o $(BIN_DIR)/$@
+	$(HIPCC) --amdgpu-target=gfx801,gfx803,gfx900,gfx902 $< -o $(BIN_DIR)/$@
 
 $(BIN_DIR):
 	mkdir -p $@

--- a/src/gpu/lulesh/Makefile
+++ b/src/gpu/lulesh/Makefile
@@ -2,7 +2,7 @@ BIN_DIR ?= ./bin
 HIP_PATH ?= /opt/rocm/hip
 
 all: $(BIN_DIR)
-	$(HIP_PATH)/bin/hipcc src/lulesh.hip.cc -o $(BIN_DIR)/lulesh --amdgpu-target=gfx801,gfx803,gfx900
+	$(HIP_PATH)/bin/hipcc src/lulesh.hip.cc -o $(BIN_DIR)/lulesh --amdgpu-target=gfx801,gfx803,gfx900,gfx902
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/bc/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/bc/Makefile.gem5-fusion
@@ -17,7 +17,7 @@ BIN_DIR ?= ./bin
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): $(CPPSRC) ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --amdgpu-target=gfx801,gfx803,gfx900 $(CXXFLAGS) ../graph_parser/util.cpp $(CPPSRC) -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
+	$(HIPCC) $(OPTS) --amdgpu-target=gfx801,gfx803,gfx900,gfx902 $(CXXFLAGS) ../graph_parser/util.cpp $(CPPSRC) -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/color/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/color/Makefile.gem5-fusion
@@ -21,7 +21,7 @@ BIN_DIR ?= ./bin
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): $(CPPFILES) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) -O3 --amdgpu-target=gfx801,gfx803,gfx900 $(CXXFLAGS) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(CPPFILES) -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
+	$(HIPCC) -O3 --amdgpu-target=gfx801,gfx803,gfx900,gfx902 $(CXXFLAGS) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(CPPFILES) -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/fw/Makefile.default
+++ b/src/gpu/pannotia/fw/Makefile.default
@@ -8,7 +8,7 @@ BIN_DIR ?= ./bin
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): Floyd-Warshall.cpp parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --amdgpu-target=gfx801,gfx803,gfx900,gfx906 $(CXXFLAGS) parse.cpp ../graph_parser/util.cpp Floyd-Warshall.cpp -o $(BIN_DIR)/$(EXECUTABLE)
+	$(HIPCC) $(OPTS) --amdgpu-target=gfx801,gfx803,gfx900,gfx902,gfx906 $(CXXFLAGS) parse.cpp ../graph_parser/util.cpp Floyd-Warshall.cpp -o $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/fw/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/fw/Makefile.gem5-fusion
@@ -12,7 +12,7 @@ BIN_DIR ?= ./bin
 all: $(BIN_DIR)/fw_hip.gem5
 
 $(BIN_DIR)/fw_hip.gem5: Floyd-Warshall.cpp parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) -O3 --amdgpu-target=gfx801,gfx803,gfx900 $(CXXFLAGS) parse.cpp ../graph_parser/util.cpp Floyd-Warshall.cpp -DGEM5_FUSION -o $(BIN_DIR)/fw_hip.gem5 $(CFLAGS) $(LDFLAGS)
+	$(HIPCC) -O3 --amdgpu-target=gfx801,gfx803,gfx900,gfx902 $(CXXFLAGS) parse.cpp ../graph_parser/util.cpp Floyd-Warshall.cpp -DGEM5_FUSION -o $(BIN_DIR)/fw_hip.gem5 $(CFLAGS) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/mis/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/mis/Makefile.gem5-fusion
@@ -15,7 +15,7 @@ BIN_DIR ?= ./bin
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): mis.cpp ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --amdgpu-target=gfx801,gfx803,gfx900 $(CXXFLAGS) mis.cpp ../graph_parser/parse.cpp ../graph_parser/util.cpp -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
+	$(HIPCC) $(OPTS) --amdgpu-target=gfx801,gfx803,gfx900,gfx902 $(CXXFLAGS) mis.cpp ../graph_parser/parse.cpp ../graph_parser/util.cpp -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/pagerank/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/pagerank/Makefile.gem5-fusion
@@ -23,7 +23,7 @@ BIN_DIR ?= ./bin
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): $(CPPFILES) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --amdgpu-target=gfx801,gfx803,gfx900 $(CXXFLAGS) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(CPPFILES) -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
+	$(HIPCC) $(OPTS) --amdgpu-target=gfx801,gfx803,gfx900,gfx902 $(CXXFLAGS) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(CPPFILES) -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/sssp/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/sssp/Makefile.gem5-fusion
@@ -24,7 +24,7 @@ BIN_DIR ?= ./bin
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): $(CPPFILES) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) -O3 --amdgpu-target=gfx801,gfx803,gfx900 $(CXXFLAGS) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(CPPFILES) -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
+	$(HIPCC) -O3 --amdgpu-target=gfx801,gfx803,gfx900,gfx902 $(CXXFLAGS) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(CPPFILES) -DGEM5_FUSION -o $(BIN_DIR)/$(EXECUTABLE) $(CFLAGS) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/square/Makefile
+++ b/src/gpu/square/Makefile
@@ -6,7 +6,7 @@ BIN_DIR?= ./bin
 square: $(BIN_DIR)/square
 
 $(BIN_DIR)/square: square.cpp $(BIN_DIR)
-	$(HIPCC) --amdgpu-target=gfx801,gfx803,gfx900 $(CXXFLAGS) square.cpp -o $(BIN_DIR)/square
+	$(HIPCC) --amdgpu-target=gfx801,gfx803,gfx900,gfx902 $(CXXFLAGS) square.cpp -o $(BIN_DIR)/square
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)


### PR DESCRIPTION
This adds gfx902 as a target for DNNMark's generate_cachefiles.py script and added the target to the Makefiles.  Note that the Makefiles can be overridden anyway with the HCC_AMDGPU_TARGET and this is the approach required to build HACC and PENNANT as the lines in the Makefile are actually ignored/do not exist. However, by adding the targets, resources can be built on real hardware with a simple 'make' command.

This is related to the discussion on the gem5 main repository about deprecating GCN3: https://github.com/orgs/gem5/discussions/306 . As a first step, we want to confirm that a Vega APU target works.  That target is gfx902.  I have tested everything in gem5-resources now and everything works as well as it does on gfx900 (dGPU target).  I have uploaded the scripts I used for testing here: https://github.com/abmerop/gem5/commit/89f7dba10062eeaf879e489ba76e87dc1baf8df9 . There is no intention of committing these scripts.  The commit is linked solely for reference.