### PR TITLE
resources: SPEC 2017 benchmark suite on ARM64 Ubuntu 22.04 Disk Image

### DIFF
--- a/src/spec-2017-ubuntu-22.04/README.md
+++ b/src/spec-2017-ubuntu-22.04/README.md
@@ -1,0 +1,199 @@
+# SPEC 2017 Benchmark Suite on ARM64 Ubuntu 22.04 Disk Image
+
+This file first documents how to build an ARM64 disk image with an installation of the SPEC 2017 benchmark suite, then describes how to use it as a gem5 resource.
+
+## Part 1: Making the disk image
+
+The following tutorial was followed, with some changes:
+
+https://github.com/takekoputa/hpc-disk-image/tree/main
+
+
+Note: All shell scripts should be run in the same directory that they are located in. That is, you should `cd` into the directory and run them with `./script_name.sh`. They were either provided by the tutorial as a file, or were commands provided in the tutorial that were made into shell scripts for ease of use.
+
+### Summary
+In short, you will need to:
+
+0. Place your copy of the SPEC 2017 disk image in the `packer-files` directory, or alter the filepath in `arm64-hpc.json` so it points to your copy of the disk image.
+
+1. Obtain Packer by running `packer-obtain.sh` in the `packer-files` directory.
+
+2. Obtain the ARM Ubuntu disk image by running `get-disk-img.sh` in the `qemu-files` directory.
+
+3. Generate a new pair of ssh keys and modify `arm64-hpc.json` and `cloud.txt` to match.
+
+4. Create `cloud.img` with `make-cloud-img.sh`.
+
+5. Launch a QEMU instance with `qemu-launch.sh`.
+
+6. Run Packer with `./packer build arm64-hpc.json`.
+
+7. Power off the QEMU instance with `qemu-logout.sh`, then launch the QEMU instance again. You will now be able to interact with the disk image via the terminal as the root user.
+
+8. Run `install-spec2017.sh` in the QEMU instance (as the root user).
+
+9. Poweroff the QEMU instance.
+
+### Steps
+(0) You will need to obtain your own copy of the SPEC 2017 disk image. To use it with this tutorial, you can copy it into the `packer-files` directory. Alternatively, you can change the filepath to the disk image in `arm64-hpc.json`. The filepath can be found under "provisioners", then "source" of the third entry in the "provisioners" section.
+
+(1) Change the Packer version at the top of `packer-obtain.sh` to the latest version, then run `packer-obtain.sh`.
+
+After obtaining Packer, step 5 of the linked tutorial, "5. Building the arm64 Disk Image", was followed. 
+
+(2) Most of the relevant files from the linked tutorial are already included here, with the exception of the ARM64 Ubuntu 22.04 disk image. This can be obtained by running `get-disk-img.sh` in the `qemu_files` directory, which corresponds to step 5.1 of the tutorial. The disk image will be placed in the `qemu_files` directory, and will be named `arm64-hpc-2204.img`.
+
+(3) You will also need to generate a new pair of ssh keys, copy the public key into `cloud.txt`, and change the filepath to the private key in `arm64-hpc.json`. 
+- The private key filepath in `arm64-hpc.json` is under "ssh_certificate_file", in "builders"
+- The public key in `cloud.txt` is under ssh-authorized-keys, at the bottom of the file.
+
+(4, 5) After this, make cloud.img by running `make-cloud-img.sh` and launch the disk image with `qemu-launch.sh`.
+
+(6) After launching the QEMU instance, run Packer (in a different terminal) using `./packer build arm64-hpc.json` in the packer_files directory. 
+
+If you want to see debug messages when running Packer, use
+`PACKER_LOG=1 ./packer build arm64-hpc.json`.
+
+If Packer hangs on "Waiting for ssh", follow the troubleshooting steps at the bottom of the linked tutorial. If a "Permission denied (publickey)" error occurs when attempting to ssh, try the following:
+```
+eval `ssh-agent -s`
+ssh-add ~/.ssh/id_rsa    # or path to file with private key
+```
+
+(7) After Packer finishes, exit the QEMU instance by running `qemu-logout.sh` from another terminal window, which connects to the disk image with ssh and shuts it down remotely. Re-launch the QEMU instance with `qemu-launch.sh`. Unlike before, where you were prompted for an Ubuntu login and password, you will now be automatically logged in as the root user.
+
+(8, 9, 10) If you try to run `install-spec2017.sh` as part of the Packer build, Packer won't be able to mount the SPEC 2017 disk image. However, you will be able to run `install-spec2017.sh` when logged in as the root user. Packer will have placed `install-spec2017.sh` into the directory `/home/ubuntu` of the QEMU instance. Run this script, then log out of the QEMU instance by running `qemu-logout.sh` in another terminal window, or by running the `poweroff` command in the QEMU instance.
+
+
+## Part 2: Using the disk image as a resource
+The disk image can be used as a DiskImageResource when setting the board's workload in the Python script:
+
+```
+board.set_kernel_disk_workload(
+    kernel=obtain_resource("arm64-linux-kernel-5.15.36"),
+    disk_image=DiskImageResource
+    (
+        local_path="local/path/to/arm64-hpc-2204.img",
+        root_partition="1" #make sure to have this, otherwise it won't boot
+    ),
+    bootloader=obtain_resource("arm64-bootloader-foundation"),
+    readfile_contents=command
+
+    )
+```
+
+For `readfile_contents`, you can use the following for `command`:
+
+```
+command = (
+    "cd /home/ubuntu/gem5/spec2017;" +
+    "source shrc;" +
+    f"runcpu --size {args.size} --iterations 1 --config myconfig.arm.cfg --define gcc_dir='/usr' --noreportable --nobuild {args.benchmark};")
+```
+
+These are the commands run by gem5 after Ubuntu finishes booting. If desired, you can add or remove flags and arguments from the last line.
+
+
+### Part 3: Successfully built benchmarks
+Some benchmarks encounter build errors, so not all of them are available. The  benchmarks that I observed to be successfully built are as follows:
+
+```
+"500.perlbench_r", 
+"631.deepsjeng_s",
+"638.imagick_s",  
+"505.mcf_r",    
+"641.leela_s",            
+"507.cactuBSSN_r",  
+"644.nab_s",             
+"508.namd_r",      
+"648.exchange2_s",     
+"510.parest_r",     
+"649.fotonik3d_s",     
+"511.povray_r",   
+"654.roms_s",     
+"519.lbm_r",   
+"657.xz_s",  
+"520.omnetpp_r",  
+"996.specrand_fs",   
+"997.specrand_fr",  
+"523.xalancbmk_r",
+"998.specrand_is", 
+"999.specrand_ir", 
+"526.blender_r", 
+"531.deepsjeng_r", 
+"538.imagick_r" 
+"541.leela_r", 
+"544.nab_r", 
+"548.exchange2_r",
+"549.fotonik3d_r",
+"554.roms_r", 
+"557.xz_r", 
+"600.perlbench_s",  
+"602.gcc_s",  
+"605.mcf_s",   
+"603.bwaves_s",
+"607.cactuBSSN_s"  
+"619.lbm_s", 
+"620.omnetpp_s",  
+"623.xalancbmk_s", 
+```
+
+Some benchmark suites are missing benchmarks. These will still run, skipping the benchmarks that could not be successfully built. 
+
+The benchmark suites are:
+
+```
+"fpspeed_mixed_cpp.bset",
+"fpspeed_mixed_c.bset", 
+"fpspeed_mixed_fortran.bset",
+"fpspeed_pure_c.bset",
+"fpspeed_pure_fortran.bset", 
+"intopenmp.bset", 
+"intrate.bset",
+"intrate_any_c.bset", 
+"intrate_any_cpp.bset", 
+"intrate_any_fortran.bset",
+"intrate_pure_c.bset",  
+"intrate_pure_cpp.bset",    
+"intrate_pure_fortran.bset", 
+"CPU.bset",      
+"intspeed.bset",  
+"any_c.bset",      
+"intspeed_any_c.bset",   
+"any_cpp.bset", 
+"intspeed_any_cpp.bset",   
+"any_fortran.bset",  
+"intspeed_any_fortran.bset",
+"fpopenmp.bset",  
+"intspeed_pure_c.bset",   
+"fprate.bset",  
+"intspeed_pure_cpp.bset",   
+"fprate_any_c.bset",
+"intspeed_pure_fortran.bset", 
+"fprate_any_cpp.bset", 
+"mixed.bset", 
+"fprate_any_fortran.bset", 
+"mixed_c.bset",
+"fprate_mixed.bset",     
+"mixed_cpp.bset", 
+"fprate_mixed_c.bset",       
+"mixed_fortran.bset",
+"fprate_mixed_cpp.bset",      
+"openmp.bset",
+"fprate_mixed_fortran.bset",  
+"pure_c.bset",
+"fprate_pure_c.bset",         
+"pure_cpp.bset",
+"fprate_pure_cpp.bset"      
+"pure_fortran.bset"
+"fprate_pure_fortran.bset",   
+"serial.bset",
+"fpspeed.bset",               
+"serial_speed.bset",
+"fpspeed_any_c.bset",         
+"specrate.bset",
+"fpspeed_any_cpp.bset",       
+"specspeed.bset",
+"fpspeed_any_fortran.bset",
+"fpspeed_mixed.bset"
+```

--- a/src/spec-2017-ubuntu-22.04/packer-files/1.packages-install.sh
+++ b/src/spec-2017-ubuntu-22.04/packer-files/1.packages-install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+sudo apt-get -y update
+sudo apt-get -y upgrade
+sudo apt-get -y install build-essential git python3-pip gfortran cmake ninja-build git-lfs
+pip install scons --user
+pip install meson --user
+
+# Removing snapd
+sudo snap remove $(snap list | awk '!/^Name|^core/ {print $1}') # not removing the core package as others depend on it
+sudo snap remove $(snap list | awk '!/^Name/ {print $1}')
+sudo systemctl disable snapd.service
+sudo systemctl disable snapd.socket
+sudo systemctl disable snapd.seeded.service
+sudo apt remove --purge -y snapd
+sudo apt -y autoremove
+sudo apt -y autopurge
+
+# Removing mounting /boot/efi
+sudo sed -i '/\/boot\/efi/d' /etc/fstab
+sudo systemctl stop boot-efi.mount
+sudo systemctl disable boot-efi.mount
+
+# Removing cloud-init
+sudo touch /etc/cloud/cloud-init.disabled

--- a/src/spec-2017-ubuntu-22.04/packer-files/2.m5-install.sh
+++ b/src/spec-2017-ubuntu-22.04/packer-files/2.m5-install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright (c) 2023 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+cd $HOME
+git clone https://github.com/gem5/gem5
+cd $HOME/gem5/util/m5
+/home/ubuntu/.local/bin/scons arm64.CROSS_COMPILE= build/arm64/out/m5
+
+sudo mv /home/ubuntu/serial-getty@.service /lib/systemd/system/
+sudo mv /home/ubuntu/gem5/util/m5/build/arm64/out/m5 /sbin
+sudo ln -s /sbin/m5 /sbin/gem5
+sudo mv /home/ubuntu/gem5-init.sh /root/
+sudo chmod +x /root/gem5-init.sh
+sudo sh -c "echo \"/root/gem5-init.sh\" >> /root/.bashrc"

--- a/src/spec-2017-ubuntu-22.04/packer-files/arm64-hpc.json
+++ b/src/spec-2017-ubuntu-22.04/packer-files/arm64-hpc.json
@@ -1,0 +1,53 @@
+{
+    "_author": "Hoa Nguyen <hoanguyen@ucdavis.edu>",
+    "_license": "Copyright (c) 2023 The Regents of the University of California. SPDX-License-Identifier: BSD 3-Clause",
+    "builders":
+    [
+        {
+            "type": "null",
+            "ssh_host": "localhost",
+            "ssh_port": "5556",
+            "ssh_username": "{{ user `ssh_username` }}",
+            "ssh_agent_auth": true,
+            "ssh_ciphers":  ["aes128-gcm@openssh.com", "chacha20-poly1305@openssh.com", "aes128-ctr", "aes192-ctr", "aes256-ctr"],
+            "ssh_certificate_file": "~/.ssh/arm64-spec2017_id_rsa",
+            "ssh_clear_authorized_keys": true
+        }
+    ],
+    "provisioners":
+    [
+        {
+            "type": "file",
+            "source": "gem5-init.sh",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "file",
+            "source": "serial-getty@.service",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "file",
+            "source": "cpu2017-1.1.0.iso",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "file",
+            "source": "install-spec2017.sh",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "shell",
+            "execute_command": "{{.Vars}} bash '{{.Path}}'",
+            "scripts":
+            [
+                "1.packages-install.sh",
+                "2.m5-install.sh"
+            ]
+        }
+    ],
+    "variables":
+    {
+        "ssh_username": "ubuntu"
+    }
+}

--- a/src/spec-2017-ubuntu-22.04/packer-files/gem5-init.sh
+++ b/src/spec-2017-ubuntu-22.04/packer-files/gem5-init.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# if IGNORE_M5 is not 1, the command will be read from m5 readfile
+if ! [[ "$IGNORE_M5" == 1 ]]; then
+    # m5 readfile returns the number of bytes read
+    # if it returns 0, it means there's no inputted command
+    if m5 readfile > script.sh; then
+        chmod +x script.sh;
+        echo "Executing the following commands"
+        echo "//------"
+        cat script.sh
+        echo "//------"
+        ./script.sh
+        sleep 1
+        m5 exit
+    else
+        echo "No inputted command. Dropping to bash."
+        IGNORE_M5=1 /bin/bash
+    fi
+fi
+

--- a/src/spec-2017-ubuntu-22.04/packer-files/install-spec2017.sh
+++ b/src/spec-2017-ubuntu-22.04/packer-files/install-spec2017.sh
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+# install build-essential (gcc and g++ included) and gfortran
+echo "12345" | sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential gfortran
+
+# mount the SPEC2017 ISO file and install SPEC to the disk image
+mkdir /home/ubuntu/gem5/mnt
+mount -o loop -t iso9660 /home/ubuntu/cpu2017-1.1.0.iso /home/ubuntu/gem5/mnt
+mkdir /home/ubuntu/gem5/spec2017
+echo "yes" | /home/ubuntu/gem5/mnt/install.sh -d /home/ubuntu/gem5/spec2017
+cd /home/ubuntu/gem5/spec2017
+. /home/ubuntu/gem5/mnt/shrc
+umount /home/ubuntu/gem5/mnt
+# rm -f /home/ubuntu/gem5/cpu2017-1.1.0.iso
+
+# use the example config as the template
+cp /home/ubuntu/gem5/spec2017/config/Example-gcc-linux-aarch64.cfg /home/ubuntu/gem5/spec2017/config/myconfig.arm.cfg
+
+# use sed command to remove the march=native flag when compiling
+# this is necessary as the packer script runs in kvm mode, so the details of the CPU will be that of the host CPU
+# the -march=native flag is removed to avoid compiling instructions that gem5 does not support
+# finetuning flags should be manually added
+sed -i "s/-march=native//g" /home/ubuntu/gem5/spec2017/config/myconfig.arm.cfg
+
+# prevent runcpu from calling sysinfo
+# https://www.spec.org/cpu2017/Docs/config.html#sysinfo-program
+# this is necessary as the sysinfo program queries the details of the system's CPU
+# the query causes gem5 runtime error
+sed -i "s/command_add_redirect = 1/sysinfo_program =\ncommand_add_redirect = 1/g" /home/ubuntu/gem5/spec2017/config/myconfig.arm.cfg
+
+# build all SPEC workloads
+# build_ncpus: number of cpus to build the workloads
+# gcc_dir: where to find the compilers (gcc, g++, gfortran)
+runcpu --config=myconfig.arm.cfg --define build_ncpus=$(nproc) --define gcc_dir="/usr" --action=build all
+
+# the above building process will produce a large log file
+# this command removes the log files to avoid copying out large files unnecessarily
+rm -f /home/ubuntu/gem5/spec2017/result/*

--- a/src/spec-2017-ubuntu-22.04/packer-files/packer-obtain.sh
+++ b/src/spec-2017-ubuntu-22.04/packer-files/packer-obtain.sh
@@ -1,0 +1,7 @@
+PACKER_VERSION="1.9.2"
+
+if [ ! -f ./packer ]; then
+    wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_arm64.zip;
+    unzip packer_${PACKER_VERSION}_linux_arm64.zip;
+    rm packer_${PACKER_VERSION}_linux_arm64.zip;
+fi

--- a/src/spec-2017-ubuntu-22.04/packer-files/serial-getty@.service
+++ b/src/spec-2017-ubuntu-22.04/packer-files/serial-getty@.service
@@ -1,0 +1,46 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Serial Getty on %I
+Documentation=man:agetty(8) man:systemd-getty-generator(8)
+Documentation=http://0pointer.de/blog/projects/serial-console.html
+BindsTo=dev-%i.device
+After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service getty-pre.target
+After=rc-local.service
+
+# If additional gettys are spawned during boot then we should make
+# sure that this is synchronized before getty.target, even though
+# getty.target didn't actually pull it in.
+Before=getty.target
+IgnoreOnIsolate=yes
+
+# IgnoreOnIsolate causes issues with sulogin, if someone isolates
+# rescue.target or starts rescue.service from multi-user.target or
+# graphical.target.
+Conflicts=rescue.service
+Before=rescue.service
+
+[Service]
+# The '-o' option value tells agetty to replace 'login' arguments with an
+# option to preserve environment (-p), followed by '--' for safety, and then
+# the entered username.
+ExecStart=-/sbin/agetty --autologin root --keep-baud 115200,38400,9600 %I $TERM
+Type=idle
+Restart=always
+UtmpIdentifier=%I
+TTYPath=/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+KillMode=process
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+
+[Install]
+WantedBy=getty.target

--- a/src/spec-2017-ubuntu-22.04/qemu-files/cloud.txt
+++ b/src/spec-2017-ubuntu-22.04/qemu-files/cloud.txt
@@ -1,0 +1,9 @@
+#cloud-config
+users:
+  - name: ubuntu
+    lock_passwd: false
+    groups: sudo
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - (ssh public key goes here)

--- a/src/spec-2017-ubuntu-22.04/qemu-files/get-disk-img.sh
+++ b/src/spec-2017-ubuntu-22.04/qemu-files/get-disk-img.sh
@@ -1,0 +1,3 @@
+wget https://cloud-images.ubuntu.com/releases/22.04/release-20230616/ubuntu-22.04-server-cloudimg-arm64.img
+qemu-img convert ubuntu-22.04-server-cloudimg-arm64.img -O raw ./arm64-hpc-2204.img
+qemu-img resize -f raw arm64-hpc-2204.img +16G

--- a/src/spec-2017-ubuntu-22.04/qemu-files/make-cloud-img.sh
+++ b/src/spec-2017-ubuntu-22.04/qemu-files/make-cloud-img.sh
@@ -1,0 +1,1 @@
+cloud-localds --disk-format qcow2 cloud.img cloud.txt

--- a/src/spec-2017-ubuntu-22.04/qemu-files/qemu-launch.sh
+++ b/src/spec-2017-ubuntu-22.04/qemu-files/qemu-launch.sh
@@ -1,0 +1,10 @@
+dd if=/dev/zero of=flash0.img bs=1M count=64
+dd if=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd of=flash0.img conv=notrunc
+dd if=/dev/zero of=flash1.img bs=1M count=64
+qemu-system-aarch64 -m 16384 -smp 8 -cpu cortex-a57 -M virt \
+    -nographic -pflash flash0.img -pflash flash1.img \
+    -drive if=none,file=arm64-hpc-2204.img,id=hd0 -device virtio-blk-device,drive=hd0 \
+    -drive if=none,id=cloud,file=cloud.img -device virtio-blk-device,drive=cloud \
+    -netdev user,id=user0 -device virtio-net-device,netdev=eth0 \
+    -netdev user,id=eth0,hostfwd=tcp::5556-:22
+

--- a/src/spec-2017-ubuntu-22.04/qemu-files/qemu-logout.sh
+++ b/src/spec-2017-ubuntu-22.04/qemu-files/qemu-logout.sh
@@ -1,0 +1,2 @@
+ssh -p 5556 ubuntu@localhost \
+sudo poweroff


### PR DESCRIPTION
This pull request adds the files and instructions needed to make a ARM64 Ubuntu 22.04 disk image, and to install the SPEC 2017 benchmark suite on the disk image. The `qemu-files` directory contains the files for getting the disk image and launching it as a QEMU instance. The `packer-files` directory contains the files that Packer needs to build the disk image, as well as a script for obtaining Packer. README.md contains detailed instructions on how to build the disk image and install SPEC 2017 using the scripts and files provided.

I tested this by running a few gem5 simulations with the disk image that I made to figure out the process of building the disk image. Next, I launched the disk image as a QEMU instance and checked if the benchmarks that had built successfully would run. Finally, I built another disk image as part of writing the documentation, and used it as a resource to run another gem5 simulation.