### PR TITLE
resources: SPEC 2006 benchmark suite on ARM64 Ubuntu 22.04 Disk Image

### DIFF
--- a/src/spec-2006-ubuntu-22.04/README.md
+++ b/src/spec-2006-ubuntu-22.04/README.md
@@ -1,0 +1,125 @@
+# SPEC 2006 Benchmark Suite on ARM64 Ubuntu 22.04 Disk Image
+
+This file first documents how to build an ARM64 disk image with an installation of the SPEC 2006 benchmark suite, then describes how to use it as a gem5 resource.
+
+## Part 1: Making the disk image
+
+The following tutorial was followed, with some changes:
+
+https://github.com/takekoputa/hpc-disk-image/tree/main
+
+
+Note: All shell scripts should be run in the same directory that they are located in. That is, you should `cd` into the directory and run them with `./script_name.sh`. They were either provided by the tutorial as a file, or were commands provided in the tutorial that were made into shell scripts for ease of use.
+
+### Summary
+In short, you will need to:
+
+0. Place your copy of the SPEC 2006 disk image in the `packer-files` directory, or alter the filepath in `arm64-hpc.json` so it points to your copy of the disk image.
+
+1. Obtain Packer by running `packer-obtain.sh` in the `packer-files` directory.
+
+2. Obtain the ARM Ubuntu disk image by running `get-disk-img.sh` in the `qemu-files` directory.
+
+3. Generate a new pair of ssh keys and modify `arm64-hpc.json` and `cloud.txt` to match.
+
+4. Create `cloud.img` with `make-cloud-img.sh`.
+
+5. Launch a QEMU instance with `qemu-launch.sh`.
+
+6. Run Packer with `./packer build arm64-hpc.json`.
+
+7. Power off the QEMU instance with `qemu-logout.sh`, then launch the QEMU instance again. You will now be able to interact with the disk image via the terminal as the root user.
+
+8a. Run `install-spec2006.sh` line-by-line, up to `PERLFLAGS="-A libs=-lm -A libs=-ldl" ./buildtools`, to mount the SPEC 2006 disk image.
+
+9. Before running the line
+`PERLFLAGS="-A libs=-lm -A libs=-ldl" ./buildtools`, 
+make edits to several of the files in the mounted SPEC2006, according to this 
+document: https://github.com/studyztp/some-notes/blob/main/SPEC2006_RISCV_ubuntu20.04.4_issue_note.md . For your convenience, you can run the script `replace-configs.sh`, located in `/home/ubuntu` of the QEMU instance, to make the first change.
+
+8b. Continue running `install-spec2006.sh` line-by-line, picking up from where you left off. 
+
+10. Poweroff the QEMU instance.
+
+
+
+### Steps
+(0) You will need to obtain your own copy of the SPEC 2006 disk image. To use it with this tutorial, you can copy it into the `packer-files` directory. Alternatively, you can change the filepath to the disk image in `arm64-hpc.json`. The filepath can be found under "provisioners", then "source" of the third entry in the "provisioners" section.
+
+(1) Change the Packer version at the top of `packer-obtain.sh` to the latest version, then run `packer-obtain.sh`.
+
+After obtaining Packer, step 5 of the linked tutorial, "5. Building the arm64 Disk Image", was followed. 
+
+(2) Most of the relevant files from the linked tutorial are already included here, with the exception of the ARM64 Ubuntu 22.04 disk image. This can be obtained by running `get-disk-img.sh` in the `qemu_files` directory, which corresponds to step 5.1 of the tutorial. The disk image will be placed in the `qemu_files` directory, and will be named `arm64-hpc-2204.img`.
+
+(3) You will also need to generate a new pair of ssh keys, copy the public key into `cloud.txt`, and change the filepath of the private key in `arm64-hpc.json`. 
+- The private key filepath in `arm64-hpc.json` is under "ssh_certificate_file", in "builders"
+- The public key in `cloud.txt` is under `ssh-authorized-keys`, at the bottom of the file.
+
+(4, 5) After this, make cloud.img by running `make-cloud-img.sh` and launch the disk image with `qemu-launch.sh`.
+
+(6) After launching the QEMU instance, run Packer (in a different terminal) using `./packer build arm64-hpc.json` in the packer_files directory. 
+
+If you want to see debug messages when running Packer, use
+`PACKER_LOG=1 ./packer build arm64-hpc.json`
+
+If Packer hangs on "Waiting for ssh", follow the troubleshooting steps at the bottom of the linked tutorial. If a "Permission denied (publickey)" error occurs when attempting to ssh, try the following:
+```
+eval `ssh-agent -s`
+ssh-add ~/.ssh/id_rsa    # or path to file with private key
+```
+
+(7) Packer is unable to run `install-spec2006.sh` when building. There are several potential points of failure, but the one you will most likely encounter is that Packer will fail to mount the SPEC 2006 disk image. After Packer finishes building, you will be able to log into the QEMU instance as the root user.
+Run `qemu-logout.sh`, then re-launch the QEMU instance wih `qemu-launch.sh`.
+
+
+(8a) By this point, you should have a disk image that boots as the root user on an Ubuntu 22.04 operating system and has the SPEC 2006 disk image in `/home/ubuntu`. Paste the commands in `install-spec2006.sh`, up to but NOT including `PERLFLAGS="-A libs=-lm -A libs=-ldl" ./buildtools` into the QEMU instance's terminal. These commands mount the disk image.
+
+(9)The following webpage contains various fixes for problems that were encountered during the tools installation:
+
+https://github.com/studyztp/some-notes/blob/main/SPEC2006_RISCV_ubuntu20.04.4_issue_note.md
+
+After making the changes listed in the above document, you should be able to finish the tools installation. The script `replace-configs.sh` will do the first change in the document, which is about updating config.guess and config.sub.
+
+If you unmount and remount the disk, the changes will be reset. As such, it is much more efficient to run each command in `install-spec2006.sh` individually, rather than running the entire script. 
+
+(8b) Continue running the rest of `install-spec2006.sh`.
+
+After the tools installation, the benchmark installation should proceed relatively smoothly. You may need to run `source shrc` or `filepath_to_shrc/shrc` in the spec2006 directory before attempting the benchmark installation. Otherwise, you may receive the error "runspec: command not found".
+
+After `install-spec2006.sh`, run `poweroff` in the QEMU instance to shut down the disk image.
+
+## Part 2: Using the disk image as a resource
+The disk image can be used as a DiskImageResource when setting the board's workload in the Python script:
+
+```
+board.set_kernel_disk_workload(
+    kernel=obtain_resource("arm64-linux-kernel-5.15.36"),
+    disk_image=DiskImageResource
+    (
+        local_path="local/path/to/arm64-hpc-2204.img",
+        root_partition="1" #make sure to have this, otherwise it won't boot
+    ),
+    bootloader=obtain_resource("arm64-bootloader-foundation"),
+    readfile_contents=command
+
+    )
+```
+
+For `readfile_contents`, you can use the following for `command`:
+
+```
+command = (
+    "cd /home/ubuntu/gem5/spec2006;" +
+    "source shrc;"+
+    f"runspec --config=myconfig.cfg --size={args.size} --noreportable --action run {args.benchmark};")
+```
+
+These are the commands run by gem5 after Ubuntu finishes booting. If desired, you can add or remove flags and arguments from the last line.
+
+
+
+### Part 3: Successfully built benchmarks
+Not all of the benchmarks can be built successfully, so only some of them are available. The benchmarks that I observed could run are the following:
+
+444.namd, 465.tonto, 401.bzip2, 445.gobmk, 470.lbm, 403.gcc, 471.omnetpp, 410.bwaves, 473.astar, 453.povray, 429.mcf, 454.calculix, 433.milc, 456.hmmer, 434.zeusmp, 458.sjeng, 998.specrand, 435.gromacs, 459.GemsFDTD, 999.specrand, 436.cactusADM, 462.libquantum, 437.leslie3d, 464.h264ref

--- a/src/spec-2006-ubuntu-22.04/packer-files/1.packages-install.sh
+++ b/src/spec-2006-ubuntu-22.04/packer-files/1.packages-install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+sudo apt-get -y update
+sudo apt-get -y upgrade
+sudo apt-get -y install build-essential git python3-pip gfortran cmake ninja-build git-lfs
+pip install scons --user
+pip install meson --user
+
+# Removing snapd
+sudo snap remove $(snap list | awk '!/^Name|^core/ {print $1}') # not removing the core package as others depend on it
+sudo snap remove $(snap list | awk '!/^Name/ {print $1}')
+sudo systemctl disable snapd.service
+sudo systemctl disable snapd.socket
+sudo systemctl disable snapd.seeded.service
+sudo apt remove --purge -y snapd
+sudo apt -y autoremove
+sudo apt -y autopurge
+
+# Removing mounting /boot/efi
+sudo sed -i '/\/boot\/efi/d' /etc/fstab
+sudo systemctl stop boot-efi.mount
+sudo systemctl disable boot-efi.mount
+
+# Removing cloud-init
+sudo touch /etc/cloud/cloud-init.disabled

--- a/src/spec-2006-ubuntu-22.04/packer-files/2.m5-install.sh
+++ b/src/spec-2006-ubuntu-22.04/packer-files/2.m5-install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright (c) 2023 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+cd $HOME
+git clone https://gem5.googlesource.com/public/gem5/
+cd $HOME/gem5/util/m5
+/home/ubuntu/.local/bin/scons arm64.CROSS_COMPILE= build/arm64/out/m5
+
+sudo mv /home/ubuntu/serial-getty@.service /lib/systemd/system/
+sudo mv /home/ubuntu/gem5/util/m5/build/arm64/out/m5 /sbin
+sudo ln -s /sbin/m5 /sbin/gem5
+sudo mv /home/ubuntu/gem5-init.sh /root/
+sudo chmod +x /root/gem5-init.sh
+sudo sh -c "echo \"/root/gem5-init.sh\" >> /root/.bashrc"

--- a/src/spec-2006-ubuntu-22.04/packer-files/arm64-hpc.json
+++ b/src/spec-2006-ubuntu-22.04/packer-files/arm64-hpc.json
@@ -1,0 +1,58 @@
+{
+    "_author": "Hoa Nguyen <hoanguyen@ucdavis.edu>",
+    "_license": "Copyright (c) 2023 The Regents of the University of California. SPDX-License-Identifier: BSD 3-Clause",
+    "builders":
+    [
+        {
+            "type": "null",
+            "ssh_host": "localhost",
+            "ssh_port": "5555",
+            "ssh_username": "{{ user `ssh_username` }}",
+            "ssh_agent_auth": true,
+            "ssh_ciphers":  ["aes128-gcm@openssh.com", "chacha20-poly1305@openssh.com", "aes128-ctr", "aes192-ctr", "aes256-ctr"],
+            "ssh_certificate_file": "~/.ssh/id_rsa_spec2006",
+            "ssh_clear_authorized_keys": true
+        }
+    ],
+    "provisioners":
+    [
+        {
+            "type": "file",
+            "source": "gem5-init.sh",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "file",
+            "source": "serial-getty@.service",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "file",
+            "source": "CPU2006v1.0.1.iso",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "file",
+            "source": "install-spec2006.sh",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "file",
+            "source": "replace-configs.sh",
+            "destination": "/home/ubuntu/"
+        },
+        {
+            "type": "shell",
+            "execute_command": "{{.Vars}} bash '{{.Path}}'",
+            "scripts":
+            [
+                "1.packages-install.sh",
+                "2.m5-install.sh"
+            ]
+        }
+    ],
+    "variables":
+    {
+        "ssh_username": "ubuntu"
+    }
+}

--- a/src/spec-2006-ubuntu-22.04/packer-files/gem5-init.sh
+++ b/src/spec-2006-ubuntu-22.04/packer-files/gem5-init.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# if IGNORE_M5 is not 1, the command will be read from m5 readfile
+if ! [[ "$IGNORE_M5" == 1 ]]; then
+    # m5 readfile returns the number of bytes read
+    # if it returns 0, it means there's no inputted command
+    if m5 readfile > script.sh; then
+        chmod +x script.sh;
+        echo "Executing the following commands"
+        echo "//------"
+        cat script.sh
+        echo "//------"
+        ./script.sh
+        sleep 1
+        m5 exit
+    else
+        echo "No inputted command. Dropping to bash."
+        IGNORE_M5=1 /bin/bash
+    fi
+fi
+

--- a/src/spec-2006-ubuntu-22.04/packer-files/install-spec2006.sh
+++ b/src/spec-2006-ubuntu-22.04/packer-files/install-spec2006.sh
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+# install build-essential (gcc and g++ included) and gfortran
+echo "12345" | sudo apt-get install build-essential gfortran
+
+# mount the SPEC2006 ISO file and install SPEC to the disk image
+mkdir /home/ubuntu/gem5/mnt
+mount -o loop -t iso9660 /home/ubuntu/CPU2006v1.0.1.iso /home/ubuntu/gem5/mnt
+mkdir /home/ubuntu/gem5/spec2006
+cd /home/ubuntu/gem5/spec2006/tools/src 
+PERLFLAGS="-A libs=-lm -A libs=-ldl" ./buildtools
+cd /home/ubuntu/gem5/spec2006
+. /home/ubuntu/gem5/mnt/shrc
+umount /home/ubuntu/gem5/mnt
+# rm -f /home/ubuntu/CPU2006v1.0.1.iso
+
+# use the gcc42 config as the template
+cp /home/ubuntu/gem5/spec2006/config/linux64-amd64-gcc42.cfg /home/ubuntu/gem5/spec2006/config/myconfig.cfg
+
+# Those 'sed' commands replace paths to gcc, g++ and gfortran binary from /usr/local/sles9/gcc42-0325/bin/* to /usr/bin/*
+sed -i "s/\/usr\/local\/sles9\/gcc42-0325\/bin\/gcc/\/usr\/bin\/gcc/g" /home/ubuntu/gem5/spec2006/config/myconfig.cfg
+sed -i "s/\/usr\/local\/sles9\/gcc42-0325\/bin\/g++/\/usr\/bin\/g++/g" /home/ubuntu/gem5/spec2006/config/myconfig.cfg
+sed -i "s/\/usr\/local\/sles9\/gcc42-0325\/bin\/gfortran/\/usr\/bin\/gfortran/g" /home/ubuntu/gem5/spec2006/config/myconfig.cfg
+
+# build all SPEC workloads
+runspec --config=myconfig.cfg --action=build all
+

--- a/src/spec-2006-ubuntu-22.04/packer-files/packer-obtain.sh
+++ b/src/spec-2006-ubuntu-22.04/packer-files/packer-obtain.sh
@@ -1,0 +1,7 @@
+PACKER_VERSION="1.9.2"
+
+if [ ! -f ./packer ]; then
+    wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_arm64.zip;
+    unzip packer_${PACKER_VERSION}_linux_arm64.zip;
+    rm packer_${PACKER_VERSION}_linux_arm64.zip;
+fi

--- a/src/spec-2006-ubuntu-22.04/packer-files/replace-configs.sh
+++ b/src/spec-2006-ubuntu-22.04/packer-files/replace-configs.sh
@@ -1,0 +1,8 @@
+for dir in /home/ubuntu/gem5/spec2006/tools/src/expat-1.95.8/conftools /home/ubuntu/gem5/spec2006/tools/src/tar-1.15.1/config /home/ubuntu/gem5/spec2006/tools/src/specinvoke /home/ubuntu/gem5/spec2006/tools/src/make-3.80/config; do
+
+cd $dir
+rm config.guess config.sub
+wget -O config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+wget -O config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+
+done

--- a/src/spec-2006-ubuntu-22.04/packer-files/serial-getty@.service
+++ b/src/spec-2006-ubuntu-22.04/packer-files/serial-getty@.service
@@ -1,0 +1,46 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Serial Getty on %I
+Documentation=man:agetty(8) man:systemd-getty-generator(8)
+Documentation=http://0pointer.de/blog/projects/serial-console.html
+BindsTo=dev-%i.device
+After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service getty-pre.target
+After=rc-local.service
+
+# If additional gettys are spawned during boot then we should make
+# sure that this is synchronized before getty.target, even though
+# getty.target didn't actually pull it in.
+Before=getty.target
+IgnoreOnIsolate=yes
+
+# IgnoreOnIsolate causes issues with sulogin, if someone isolates
+# rescue.target or starts rescue.service from multi-user.target or
+# graphical.target.
+Conflicts=rescue.service
+Before=rescue.service
+
+[Service]
+# The '-o' option value tells agetty to replace 'login' arguments with an
+# option to preserve environment (-p), followed by '--' for safety, and then
+# the entered username.
+ExecStart=-/sbin/agetty --autologin root --keep-baud 115200,38400,9600 %I $TERM
+Type=idle
+Restart=always
+UtmpIdentifier=%I
+TTYPath=/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+KillMode=process
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+
+[Install]
+WantedBy=getty.target

--- a/src/spec-2006-ubuntu-22.04/qemu-files/cloud.txt
+++ b/src/spec-2006-ubuntu-22.04/qemu-files/cloud.txt
@@ -1,0 +1,9 @@
+#cloud-config
+users:
+  - name: ubuntu
+    lock_passwd: false
+    groups: sudo
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCQHLIxsYTHvFpQ/oX5IkptZ5sT8hYkNGQKqXhGAkEfaoTmAdr6WUhudf0b5b0fglnXnMxx1AcQO/TnLU4BWcQUwHj1bSdvHJOE9cFYPV3anzGOuX/oGqAdkHR1Bo0Md8uhl1xMaXVi7+277eYcWJFMbdsWSdAM2N3m+CWnYl2STPW6n9icAIgEJitpuocopta9bk51nVqB9vgLJSVWWep8VU9Dx+nrEib2u+k9ZzNooCzbda0grRilzBLjSChJUoXlzU36xcgcVAJtxYLwtVIA43Tn9hxegar3bl1k+iHylsBLxii7Qslihya0R65deW+Rz7ZUD6gJBbZTFFJmiMzdVqKdmtlu2A2oNeoj9hre4xJdTIMr9gYBKYTvLaR/XncGU85eW0wi44qASyPljuQ2/DicgIhJaJ0NCP12+2KaBnH7cVmRp8e0APBT2NXZGnBuoQ7kjEBmMZ7HgCUdPLkshWCUJ80agkflCmj8ZIYjoP6UbaedYT2Y6NLExfNES9M= ubuntu@localhost

--- a/src/spec-2006-ubuntu-22.04/qemu-files/get-disk-img.sh
+++ b/src/spec-2006-ubuntu-22.04/qemu-files/get-disk-img.sh
@@ -1,0 +1,3 @@
+wget https://cloud-images.ubuntu.com/releases/22.04/release-20230616/ubuntu-22.04-server-cloudimg-arm64.img
+qemu-img convert ubuntu-22.04-server-cloudimg-arm64.img -O raw ./arm64-hpc-2204.img
+qemu-img resize -f raw arm64-hpc-2204.img +16G

--- a/src/spec-2006-ubuntu-22.04/qemu-files/make-cloud-img.sh
+++ b/src/spec-2006-ubuntu-22.04/qemu-files/make-cloud-img.sh
@@ -1,0 +1,1 @@
+cloud-localds --disk-format qcow2 cloud.img cloud.txt

--- a/src/spec-2006-ubuntu-22.04/qemu-files/qemu-launch.sh
+++ b/src/spec-2006-ubuntu-22.04/qemu-files/qemu-launch.sh
@@ -1,0 +1,10 @@
+dd if=/dev/zero of=flash0.img bs=1M count=64
+dd if=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd of=flash0.img conv=notrunc
+dd if=/dev/zero of=flash1.img bs=1M count=64
+qemu-system-aarch64 -m 16384 -smp 8 -cpu cortex-a57 -M virt \
+    -nographic -pflash flash0.img -pflash flash1.img \
+    -drive if=none,file=arm64-hpc-2204.img,id=hd0 -device virtio-blk-device,drive=hd0 \
+    -drive if=none,id=cloud,file=cloud.img -device virtio-blk-device,drive=cloud \
+    -netdev user,id=user0 -device virtio-net-device,netdev=eth0 \
+    -netdev user,id=eth0,hostfwd=tcp::5555-:22
+

--- a/src/spec-2006-ubuntu-22.04/qemu-files/qemu-logout.sh
+++ b/src/spec-2006-ubuntu-22.04/qemu-files/qemu-logout.sh
@@ -1,0 +1,2 @@
+ssh -p 5555 ubuntu@localhost \
+sudo poweroff


### PR DESCRIPTION
This pull request adds the files and instructions needed to make a ARM64 Ubuntu 22.04 disk image and install the SPEC 2006 benchmark suite on the disk image. The qemu-files directory contains the files for getting the disk image and launching it as a QEMU instance. The packer-files directory contains the files that Packer needs to build the disk image, as well as a script for obtaining Packer. README.md contains detailed instructions on how to build the disk image and install SPEC 2006 using the scripts and files provided.

I tested this by running a few gem5 simulations with the disk image that I made to figure out the process of building the disk image. Next, I launched the disk image as a QEMU instance and checked if the benchmarks that had built successfully would run. Finally, I built another disk image as part of writing the documentation, and used it as a resource to run another gem5 simulation.