### PR TITLE
resources: updated pannotia documentation for compile commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ git clone https://github.com/gem5/gem5-resources.git
 
 ```
 cd src/gpu/square
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gfx8-apu
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gfx8-apu
 ```
 
 The compiled binary can be found in `src/gpu/square/bin`
@@ -409,7 +409,7 @@ To compile:
 
 ```
 cd src/gpu/hsa-agent-pkt
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gfx8-apu
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gfx8-apu
 ```
 
 The compiled binary can be found in `src/gpu/hsa-agent-pkt/bin`
@@ -431,7 +431,7 @@ Certain apps aren't included due to complexities with either ROCm or Docker
 
 ```
 cd src/gpu/hip-samples
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make
 ```
 
 Individual programs can be made by specifying the name of the program
@@ -469,7 +469,7 @@ and the other command-line arguments for use with heterosync.
 ## Compilation
 ```
 cd src/gpu/heterosync
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make release-gfx8
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make release-gfx8
 ```
 
 The release-gfx8 target builds for gfx801, a GCN3-based APU, and gfx803, a
@@ -489,7 +489,7 @@ provided is for use with the gpu-compute model of gem5.
 ## Compilation and Running
 ```
 cd src/gpu/lulesh
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make
 ```
 
 By default, the Makefile builds for gfx801, and is placed in the 
@@ -500,7 +500,7 @@ architecture. To build GCN3_X86:
 
 ```
 # Working directory is your gem5 directory
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu scons -sQ -j$(nproc) build/GCN3_X86/gem5.opt
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu scons -sQ -j$(nproc) build/GCN3_X86/gem5.opt
 ```
 
 The following command shows how to run lulesh
@@ -513,7 +513,7 @@ are equivalent to `--options="1.0e-2 10"`.
 
 ```
 # Assuming gem5 and gem5-resources are in your working directory
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/lulesh/bin -clulesh
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/lulesh/bin -clulesh
 ```
 
 ## Pre-built binary
@@ -584,8 +584,8 @@ commands do this by using `-v ${PWD}:${PWD}` in the docker run commands
 
 ```
 cd src/gpu/DNNMark
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu ./setup.sh HIP
-docker run --rm -v ${PWD}:${PWD} -w ${PWD}/build -u $UID:$GID gcr.io/gem5-test/gcn-gpu make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu ./setup.sh HIP
+docker run --rm -v ${PWD}:${PWD} -w ${PWD}/build -u $UID:$GID ghcr.io/gem5/gcn-gpu make
 ```
 
 DNNMark uses MIOpen kernels, which are unable to be compiled on-the-fly in gem5.
@@ -595,7 +595,7 @@ benchmarks for a gfx801 GPU with 4 CUs by default
 To generate the MIOpen kernels:
 ```
 cd src/gpu/DNNMark
-docker run --rm -v ${PWD}:${PWD} -v${PWD}/cachefiles:/root/.cache/miopen/2.9.0 -w ${PWD} gcr.io/gem5-test/gcn-gpu python3 generate_cachefiles.py cachefiles.csv [--gfx-version={gfx801,gfx803}] [--num-cus=N]
+docker run --rm -v ${PWD}:${PWD} -v${PWD}/cachefiles:/root/.cache/miopen/2.9.0 -w ${PWD} ghcr.io/gem5/gcn-gpu python3 generate_cachefiles.py cachefiles.csv [--gfx-version={gfx801,gfx803}] [--num-cus=N]
 ```
 
 Due to the large amounts of memory that need to be set up for DNNMark, we have
@@ -614,13 +614,13 @@ GCN3_X86 architecture.
 To build GCN3_X86:
 ```
 # Working directory is your gem5 directory
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu scons -sQ -j$(nproc) build/GCN3_X86/gem5.opt
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu scons -sQ -j$(nproc) build/GCN3_X86/gem5.opt
 ```
 
 To run one of the benchmarks (fwd softmax) in gem5:
 ```
 # Assuming gem5 and gem5-resources are sub-directories of the current directory
-docker run --rm -v ${PWD}:${PWD} -v ${PWD}/gem5-resources/src/gpu/DNNMark/cachefiles:/root/.cache/miopen/2.9.0 -w ${PWD} gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --benchmark-root=gem5-resources/src/gpu/DNNMark/build/benchmarks/test_fwd_softmax -cdnnmark_test_fwd_softmax --options="-config gem5-resources/src/gpu/DNNMark/config_example/softmax_config.dnnmark -mmap gem5-resources/src/gpu/DNNMark/mmap.bin"
+docker run --rm -v ${PWD}:${PWD} -v ${PWD}/gem5-resources/src/gpu/DNNMark/cachefiles:/root/.cache/miopen/2.9.0 -w ${PWD} ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --benchmark-root=gem5-resources/src/gpu/DNNMark/build/benchmarks/test_fwd_softmax -cdnnmark_test_fwd_softmax --options="-config gem5-resources/src/gpu/DNNMark/config_example/softmax_config.dnnmark -mmap gem5-resources/src/gpu/DNNMark/mmap.bin"
 ```
 
 
@@ -635,7 +635,7 @@ a sample of the typical memory access patterns of FLAG.
 
 ```
 cd src/gpu/pennant
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make
 ```
 
 By default, the binary is built for gfx801 and is placed in `src/gpu/pennant/build`.
@@ -648,7 +648,7 @@ command shows how to run the sample `noh`:
 
 ```
 # Assuming gem5 and gem5-resources are in your working directory
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --benchmark-root=gem5-resources/src/gpu/pennant/build -cpennant --options="gem5-resources/src/gpu/pennant/test/noh/noh.pnt"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --benchmark-root=gem5-resources/src/gpu/pennant/build -cpennant --options="gem5-resources/src/gpu/pennant/test/noh/noh.pnt"
 ```
 
 The output gets placed in `src/gpu/pennant/test/noh/`, and the file `noh.xy`
@@ -841,7 +841,7 @@ We provide a docker image with a pre-loaded SPARC cross compiler. To use:
 
 ```
 cd src/insttest
-docker run --volume $(pwd):$(pwd) -w $(pwd) --rm gcr.io/gem5-test/sparc64-gnu-cross:latest make
+docker run --volume $(pwd):$(pwd) -w $(pwd) --rm ghcr.io/gem5/sparc64-gnu-cross:latest make
 ```
 
 The compiled binary can be found in `src/insttest/bin`.

--- a/src/gpu-fs/README.md
+++ b/src/gpu-fs/README.md
@@ -77,9 +77,9 @@ You can obtain the `vmlinux-5.4.0-105-generic` kernel using the following path f
 It is sometimes useful to build your own application and run in gem5. A docker is provided to allow users to build applications without needing to install ROCm locally. A pre-built docker image is available on gcr.io. This image can be pulled then used to build as follows:
 
 ```sh
-docker pull gcr.io/gem5-test/gpu-fs:latest
+docker pull ghcr.io/gem5/gpu-fs:latest
 cd /path/to/gem5-resources/src/gpu/square
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} gcr.io/gem5-test/gpu-fs:latest bash -c 'make clean; HCC_AMDGPU_TARGET=gfx900 make'
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} ghcr.io/gem5/gpu-fs:latest bash -c 'make clean; HCC_AMDGPU_TARGET=gfx900 make'
 ```
 
 Currently only Vega (gfx900) is supported for full system GPU simulation in gem5. It is therefore required to tell the compiler to build for this ISA using the HCC_AMDGPU_TARGET environment variable. Otherwise, the command to build the application is the same as if you were building locally.

--- a/src/gpu/DNNMark/README.md
+++ b/src/gpu/DNNMark/README.md
@@ -27,8 +27,8 @@ won't be able to link against the library. The example commands do this by using
 `-v ${PWD}:${PWD}` in the docker run commands
 ```
 cd src/gpu/DNNMark
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 ./setup.sh HIP
-docker run --rm -v ${PWD}:${PWD} -w ${PWD}/build -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 ./setup.sh HIP
+docker run --rm -v ${PWD}:${PWD} -w ${PWD}/build -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 make
 ```
 
 DNNMark uses MIOpen kernels, which are unable to be compiled on-the-fly in gem5.
@@ -38,7 +38,7 @@ benchmarks for a gfx801 GPU with 4 CUs by default
 To generate the MIOpen kernels:
 ```
 cd src/gpu/DNNMark
-docker run --rm -v ${PWD}:${PWD} -v${PWD}/cachefiles:/root/.cache/miopen/2.9.0 -w ${PWD} gcr.io/gem5-test/gcn-gpu:v22-1 python3 generate_cachefiles.py cachefiles.csv [--gfx-version={gfx801,gfx803}] [--num-cus=N]
+docker run --rm -v ${PWD}:${PWD} -v${PWD}/cachefiles:/root/.cache/miopen/2.9.0 -w ${PWD} ghcr.io/gem5/gcn-gpu:v22-1 python3 generate_cachefiles.py cachefiles.csv [--gfx-version={gfx801,gfx803}] [--num-cus=N]
 ```
 
 Due to the large amounts of memory that need to be set up for DNNMark, we have
@@ -56,13 +56,13 @@ DNNMark is a GPU application, which requires that gem5 is built with the GCN3_X8
 To build GCN3_X86:
 ```
 # Working directory is your gem5 directory
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 scons -sQ -j$(nproc) build/GCN3_X86/gem5.opt
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 scons -sQ -j$(nproc) build/GCN3_X86/gem5.opt
 ```
 
 To run one of the benchmarks (fwd softmax) in gem5:
 ```
 # Assuming gem5 and gem5-resources are sub-directories of the current directory
-docker run --rm -v ${PWD}:${PWD} -v ${PWD}/gem5-resources/src/gpu/DNNMark/cachefiles:/root/.cache/miopen/2.9.0 -w ${PWD} gcr.io/gem5-test/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --benchmark-root=gem5-resources/src/gpu/DNNMark/build/benchmarks/test_fwd_softmax -cdnnmark_test_fwd_softmax --options="-config gem5-resources/src/gpu/DNNMark/config_example/softmax_config.dnnmark -mmap gem5-resources/src/gpu/DNNMark/mmap.bin"
+docker run --rm -v ${PWD}:${PWD} -v ${PWD}/gem5-resources/src/gpu/DNNMark/cachefiles:/root/.cache/miopen/2.9.0 -w ${PWD} ghcr.io/gem5/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --benchmark-root=gem5-resources/src/gpu/DNNMark/build/benchmarks/test_fwd_softmax -cdnnmark_test_fwd_softmax --options="-config gem5-resources/src/gpu/DNNMark/config_example/softmax_config.dnnmark -mmap gem5-resources/src/gpu/DNNMark/mmap.bin"
 ```
 
 Information from the original DNNMark README included below.

--- a/src/gpu/halo-finder/Dockerfile
+++ b/src/gpu/halo-finder/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/gem5-test/gcn-gpu:latest
+FROM ghcr.io/gem5/gcn-gpu:latest
 RUN apt-get update && apt-get -y install libopenmpi-dev libomp-dev
 
 ENV HCC_AMDGPU_TARGET="gfx801,gfx803,gfx900"

--- a/src/gpu/heterosync/README.md
+++ b/src/gpu/heterosync/README.md
@@ -21,7 +21,7 @@ command-line arguments for use with heterosync.
 ## Compilation
 ```
 cd src/gpu/heterosync
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 make release-gfx8
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 make release-gfx8
 ```
 
 The release-gfx8 target builds for gfx801, a GCN3-based APU, and gfx803, a
@@ -33,7 +33,7 @@ that are currently unsupported in gem5.
 HeteroSync has multiple applications that can be run (see below).  For example, to run sleepMutex with 10 ld/st per thread, 16 WGs, and 4 iterations of the critical section:
 
 ```
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n 3 -c bin/allSyncPrims-1kernel --options="sleepMutex 10 16 4"
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n 3 -c bin/allSyncPrims-1kernel --options="sleepMutex 10 16 4"
 ```
 
 ## Pre-built binary

--- a/src/gpu/hip-samples/README.md
+++ b/src/gpu/hip-samples/README.md
@@ -28,7 +28,7 @@ Compiling the HIP samples, compiling the GCN3_X86 gem5, and running the HIP samp
 
 ```
 cd src/gpu/hip-samples
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 make
 ```
 
 Individual programs can be made by specifying the name of the program

--- a/src/gpu/hsa-agent-pkt/README.md
+++ b/src/gpu/hsa-agent-pkt/README.md
@@ -29,7 +29,7 @@ To compile:
 
 ```
 cd src/gpu/hsa-agent-pkt
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 make gfx8-apu
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 make gfx8-apu
 ```
 
 The compiled binary can be found in `src/gpu/hsa-agent-pkt/bin`

--- a/src/gpu/lulesh/README.md
+++ b/src/gpu/lulesh/README.md
@@ -20,7 +20,7 @@ Compiling LULESH, compiling the GCN3_X86 gem5, and running LULESH on gem5 is dep
 ## Compilation and Running
 ```
 cd src/gpu/lulesh
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 make
 ```
 
 By default, the makefile builds for gfx801, and is placed in the `src/gpu/lulesh/bin` folder.
@@ -30,7 +30,7 @@ To build GCN3_X86:
 
 ```
 # Working directory is your gem5 directory
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 scons -sQ -j$(nproc) build/GCN3_X86/gem5.opt
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 scons -sQ -j$(nproc) build/GCN3_X86/gem5.opt
 ```
 
 The following command shows how to run lulesh
@@ -42,7 +42,7 @@ to the run command. The default arguments are equivalent to `--options="1.0e-2 1
 
 ```
 # Assuming gem5 and gem5-resources are in your working directory
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/lulesh/bin -clulesh
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/lulesh/bin -clulesh
 ```
 
 ## Pre-built binary

--- a/src/gpu/pannotia/README.md
+++ b/src/gpu/pannotia/README.md
@@ -10,3 +10,10 @@ shortdoc: >
 ---
 
 This folder and its subfolders contain each of the 9 Pannotia benchmarks (there are 6 folders because Color, and PageRank, SSSP each have 2 versions).  All of these benchmarks have been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.  See each application's README for details on how to compile and run them in gem5 using the GCN3 GPU model.
+
+## Compiling m5ops
+To compile the m5ops:
+```
+cd gem5/util/m5
+scons build/x86/out/m5
+```

--- a/src/gpu/pannotia/bc/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/bc/Makefile.gem5-fusion
@@ -8,9 +8,9 @@ HIP_PATH ?= /opt/rocm/hip
 HIPCC = $(HIP_PATH)/bin/hipcc
 
 # these are needed for m5ops
-GEM5_PATH ?= /path/to/gem5
-CFLAGS += -I$(GEM5_PATH)/include -I../graph_parser
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+GEM5_ROOT ?= /path/to/gem5
+CFLAGS += -I$(GEM5_ROOT)/include -I../graph_parser
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 BIN_DIR ?= ./bin
 

--- a/src/gpu/pannotia/bc/README.md
+++ b/src/gpu/pannotia/bc/README.md
@@ -9,24 +9,17 @@ shortdoc: >
     Resources to build a disk image with the GCN3 Pannotia BC workload.
 ---
 
-Betweenness Centrality (BC) is a graph analytics application that is part of the Pannotia benchmark suite.  It is used to calculate betweenness centrality scores for all the vertices in a graph.  The provided version is for use with the gpu-compute model of gem5.  Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
+Betweenness Centrality (BC) is a graph analytics application that is part of the Pannotia benchmark suite.
+It is used to calculate betweenness centrality scores for all the vertices in a graph.
+The provided version is for use with the gpu-compute model of gem5.
+Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
 
 Compiling BC, compiling the GCN3_X86/Vega_X86 versions of gem5, and running BC on gem5 is dependent on the gcn-gpu docker image, `util/dockerfiles/gcn-gpu/Dockerfile` on the [gem5 stable branch](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable).
 
-## Compilation and Running
-
-To compile BC:
-
-```
-cd src/gpu/pannotia/bc
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
-```
-
-If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/bc/bin folder.
-
 ## Compiling GCN3_X86/gem5.opt
 
-BC is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.  The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
+BC is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.
+The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
 
 ```
 git clone https://gem5.googlesource.com/public/gem5
@@ -34,15 +27,31 @@ cd gem5
 docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
-## Running BC on GCN3_X86/gem5.opt
+## Compiling BC
+The Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).
 
-# Assuming gem5 and gem5-resources are in your working directory
+The docker command needs visibility to the gem5 repository for usage of the m5ops.
+Thus we run the docker command from a directory with visibility and cd into the folder before running the make command.  
+  
+To compile BC assuming the gem5 and gem5-resources repositories are in your working directory:
+
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/bc ; make gem5-fusion"
+```
+
+If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.
+By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/bc/bin folder.
+
+# Running BC on GCN3_X86/gem5.opt
+
+Assuming gem5 and gem5-resources are in your working directory:
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/bc/bin -c bc.gem5 --options="1k_128k.gr"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/bc/bin -c bc.gem5 --options="1k_128k.gr"
 ```
 
-Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input designed to run with BC.
+Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.
+We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input designed to run with BC.
 
 ## Pre-built binary
 

--- a/src/gpu/pannotia/bc/README.md
+++ b/src/gpu/pannotia/bc/README.md
@@ -19,7 +19,7 @@ To compile BC:
 
 ```
 cd src/gpu/pannotia/bc
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gem5-fusion
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
 ```
 
 If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/bc/bin folder.
@@ -31,7 +31,7 @@ BC is a GPU application, which requires that gem5 is built with the GCN3_X86 (or
 ```
 git clone https://gem5.googlesource.com/public/gem5
 cd gem5
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
 ## Running BC on GCN3_X86/gem5.opt
@@ -39,7 +39,7 @@ docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gp
 # Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/bc/bin -c bc.gem5 --options="1k_128k.gr"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/bc/bin -c bc.gem5 --options="1k_128k.gr"
 ```
 
 Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input designed to run with BC.

--- a/src/gpu/pannotia/color/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/color/Makefile.gem5-fusion
@@ -2,9 +2,9 @@ HIP_PATH ?= /opt/rocm/hip
 HIPCC = $(HIP_PATH)/bin/hipcc
 
 # these are needed for m5ops
-GEM5_PATH ?= /path/to/gem5
-CFLAGS += -I$(GEM5_PATH)/include -I/../graph_parser
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+GEM5_ROOT ?= /path/to/gem5
+CFLAGS += -I$(GEM5_ROOT)/include -I/../graph_parser
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 BASEEXE = color
 VARIANT ?= MAX

--- a/src/gpu/pannotia/color/README.md
+++ b/src/gpu/pannotia/color/README.md
@@ -9,33 +9,17 @@ shortdoc: >
     Resources to build a disk image with the GCN3 Pannotia Color workload.
 ---
 
-Graph Coloring (CLR) is a graph analytics application that is part of the Pannotia benchmark suite.  It is used to label the vertices of a graph with colors such that no two adjacent vertices share the same color.  The provided version is for use with the gpu-compute model of gem5.  Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
+Graph Coloring (CLR) is a graph analytics application that is part of the Pannotia benchmark suite.
+It is used to label the vertices of a graph with colors such that no two adjacent vertices share the same color.
+The provided version is for use with the gpu-compute model of gem5.
+Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
 
 Compiling both CLR variants, compiling the GCN3_X86/Vega_X86 versions of gem5, and running both CLR variants on gem5 is dependent on the gcn-gpu docker image, `util/dockerfiles/gcn-gpu/Dockerfile` on the [gem5 stable branch](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable).
 
-## Compilation and Running
-
-To compile Color:
-
-Color has two variants: max and maxmin.  To compile the "max" variant:
-
-```
-cd src/gpu/pannotia/clr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
-```
-
-To compile the "maxmin" variant:
-
-```
-cd src/gpu/pannotia/clr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu bash -c "export VARIANT=MAXMIN ; make gem5-fusion"
-```
-
-If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/clr/bin folder.  Moreover, by default the VARIANT variable Color's Makefile assumes the max variant is being used, hence why this variable does not need to be set for compiling it.
-
 ## Compiling GCN3_X86/gem5.opt
 
-Color is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.  The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
+Color is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.
+The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
 
 ```
 git clone https://gem5.googlesource.com/public/gem5
@@ -43,25 +27,50 @@ cd gem5
 docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
-## Running Color on GCN3_X86/gem5.opt
+## Compiling Color
+The Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).
 
+The docker command needs visibility to the gem5 repository for usage of the m5ops.
+Thus we run the docker command from a directory with visibility and cd into the folder before running the make command.  
+  
+Note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile)  
+  
+Color has two variants: max and maxmin.  To compile the "max" variant assuming the gem5 and gem5-resources are in your working directory:
+
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/color ; make gem5-fusion"
+```
+
+To compile the "maxmin" variant assuming the gem5 and gem5-resources are in your working directory:
+
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/color ; export VARIANT=MAXMIN ; make gem5-fusion"
+```
+
+If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.
+By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/clr/bin folder.
+Moreover, by default the VARIANT variable Color's Makefile assumes the max variant is being used, hence why this variable does not need to be set for compiling it.
+
+
+# Running Color on GCN3_X86/gem5.opt
+
+Assuming gem5 and gem5-resources are in your working directory.
 The following command shows how to run the CLR max version:
-
-# Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/clr/bin -c color_max.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/clr/bin -c color_max.gem5 --options="1k_128k.gr 0"
 ```
 
+Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory.
 To run the CLR maxmin version:
-
-# Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/clr/bin -c color_maxmin.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/clr/bin -c color_maxmin.gem5 --options="1k_128k.gr 0"
 ```
 
-Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input that can be run with CLR.  Note that 1k_128k is not designed for Color specifically though -- the above link has larger graphs designed to run with Color that you should consider using for larger experiments.
+Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.
+We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input that can be run with CLR.
+Note that 1k_128k is not designed for Color specifically though -- the above link has larger graphs designed to run with Color that you should consider using for larger experiments.
 
 ## Pre-built binary
 

--- a/src/gpu/pannotia/color/README.md
+++ b/src/gpu/pannotia/color/README.md
@@ -21,14 +21,14 @@ Color has two variants: max and maxmin.  To compile the "max" variant:
 
 ```
 cd src/gpu/pannotia/clr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gem5-fusion
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
 ```
 
 To compile the "maxmin" variant:
 
 ```
 cd src/gpu/pannotia/clr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu bash -c "export VARIANT=MAXMIN ; make gem5-fusion"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu bash -c "export VARIANT=MAXMIN ; make gem5-fusion"
 ```
 
 If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/clr/bin folder.  Moreover, by default the VARIANT variable Color's Makefile assumes the max variant is being used, hence why this variable does not need to be set for compiling it.
@@ -40,7 +40,7 @@ Color is a GPU application, which requires that gem5 is built with the GCN3_X86 
 ```
 git clone https://gem5.googlesource.com/public/gem5
 cd gem5
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
 ## Running Color on GCN3_X86/gem5.opt
@@ -50,7 +50,7 @@ The following command shows how to run the CLR max version:
 # Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/clr/bin -c color_max.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/clr/bin -c color_max.gem5 --options="1k_128k.gr 0"
 ```
 
 To run the CLR maxmin version:
@@ -58,7 +58,7 @@ To run the CLR maxmin version:
 # Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/clr/bin -c color_maxmin.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/clr/bin -c color_maxmin.gem5 --options="1k_128k.gr 0"
 ```
 
 Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input that can be run with CLR.  Note that 1k_128k is not designed for Color specifically though -- the above link has larger graphs designed to run with Color that you should consider using for larger experiments.

--- a/src/gpu/pannotia/fw/Floyd-Warshall.cpp
+++ b/src/gpu/pannotia/fw/Floyd-Warshall.cpp
@@ -171,8 +171,8 @@ int main(int argc, char **argv)
     // Main computation loop
     for (int k = 1; k < dim && k < MAX_ITERS; k++) {
         hipLaunchKernelGGL(HIP_KERNEL_NAME(floydwarshall), dim3(grid), dim3(threads), 0, 0, dist_d, next_d, dim, k);
+        hipDeviceSynchronize();
     }
-    hipDeviceSynchronize();
 
     //double timer4 = gettime();
     err = hipMemcpy(result, dist_d, dim * dim * sizeof(int), hipMemcpyDeviceToHost);

--- a/src/gpu/pannotia/fw/Floyd-Warshall.cpp
+++ b/src/gpu/pannotia/fw/Floyd-Warshall.cpp
@@ -194,7 +194,7 @@ int main(int argc, char **argv)
         // Below is the verification part
         // Calculate on the CPU
         int *dist = distmatrix;
-        for (int k = 0; k < dim; k++) {
+        for (int k = 1; k < dim && k < MAX_ITERS; k++) {
             for (int i = 0; i < dim; i++) {
                 for (int j = 0; j < dim; j++) {
                     if (dist[i * dim + k] + dist[k * dim + j] < dist[i * dim + j]) {

--- a/src/gpu/pannotia/fw/Floyd-Warshall.cpp
+++ b/src/gpu/pannotia/fw/Floyd-Warshall.cpp
@@ -3,6 +3,7 @@
  * Copyright © 2014 Advanced Micro Devices, Inc.                                    *
  * Copyright (c) 2015 Mark D. Hill and David A. Wood                                *
  * Copyright (c) 2021 Gaurav Jain and Matthew D. Sinclair                           *
+ * Copyright (c) 2023 James Braun and Matthew D. Sinclair                           *
  * All rights reserved.                                                             *
  *                                                                                  *
  * Redistribution and use in source and binary forms, with or without               *
@@ -65,6 +66,12 @@
 #include "../graph_parser/util.h"
 #include "kernel.h"
 #include "parse.h"
+#include <unistd.h>
+#include <sys/mman.h>
+#include <fstream>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #ifdef GEM5_FUSION
 #include <stdint.h>
@@ -84,67 +91,150 @@
 
 int main(int argc, char **argv)
 {
-    char *tmpchar;
+    char *tmpchar = NULL;
+    bool mode_set = false;
+    bool create_mmap = false;
+    bool use_mmap = false;
     bool verify_results = false;
 
-    int num_nodes;
+    int dim;
     int num_edges;
+    int * distmatrix = NULL;
+    int * result = NULL;
 
+    int opt;
     hipError_t err = hipSuccess;
 
     // Get program input
-    if (argc >= 2) {
-        tmpchar = argv[1];  // Graph input file
-    } else {
-        fprintf(stderr, "You did something wrong!\n");
-        exit(1);
-    }
-
-    if (argc >= 3) {
-        if (atoi(argv[2]) == 1) {
+    while ((opt = getopt(argc, argv, "f:hm:v")) != -1) {
+        switch (opt) {
+	case 'f':  // Input file name
+	    tmpchar = optarg;
+            break;
+	case 'h':  // Help
+            fprintf(stderr, "SWITCHES\n    -f [file name]\n            input file name\n");
+            fprintf(stderr, "    -m [mode]\n            operation mode: default (run without mmap), generate, usemmap\n");
+	    fprintf(stderr, "    -v,    verify results\n");
+	    exit(0);
+	    break;
+	case 'm':  // Mode
+	    if (strcmp(optarg, "default") == 0 || optarg[0] == '0') {
+		mode_set = true;
+	    } else if (strcmp(optarg, "generate") == 0 || optarg[0] == '1') {
+		create_mmap = true;
+	    } else if (strcmp(optarg, "usemmap") == 0 || optarg[0] == '2') {
+		use_mmap = true;
+	    } else {
+	        fprintf(stderr, "Unrecognized mode: %s\n", optarg);
+		exit(1);
+	    }
+	    break;
+	case 'v':  // Error checking
             verify_results = true;
-        }
+	    break;
+	default:
+	    fprintf(stderr, "Unrecognized switch: -%c\n", opt);
+	    exit(1);
+	break;
+	}
     }
 
-    // Parse the adjacency matrix
-    int *adjmatrix = parse_graph_file(&num_nodes, &num_edges, tmpchar);
-    int dim = num_nodes;
+    if (!(mode_set || create_mmap || use_mmap)) {
+        fprintf(stderr, "Execution mode not specified! Use -h for help\n");
+        exit(1);
+    } else if (create_mmap && verify_results) {
+        fprintf(stdout, "Ignoring error checking\n");
+    } else if (use_mmap && tmpchar != NULL) {
+        fprintf(stdout, "Ignoring input file\n");
+    } else if ((mode_set || create_mmap) && tmpchar == NULL) {
+        fprintf(stderr, "Input file not specified! Use -h for help\n");
+	exit(1);
+    }
+	
+    if (use_mmap) {
+        printf("Using an mmap!\n");
+    
+        // Get # of nodes
+        int fd = open("mmap.bin", std::ios::binary | std::fstream::in);
+	if (fd == -1) {
+	    fprintf(stderr, "error: %s\n", strerror(errno));
+	    fprintf(stderr, "You need to create an mmapped input file!\n");
+	    exit(1);
+	}
+	int offset = 0;
+        dim = *((int *)mmap(NULL, 1 * sizeof(int), PROT_READ, MAP_PRIVATE, fd, offset));
+        
+        // Read distmatrix in
+        int *distmatrixmap = (int *)mmap(NULL, (dim * dim + 1) * sizeof(int), PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, offset);
+        
+        // Check that mmaping was successful
+        if (distmatrixmap == MAP_FAILED) {
+	    fprintf(stderr, "mmap failed\n");
+	    exit(1);
+	}
+	
+        // move everything to array from index 1
+        distmatrix = (int *)malloc(dim * dim * sizeof(int));
+        memcpy(distmatrix, &distmatrixmap[1], dim * dim * sizeof(int));
 
-    // Initialize the distance matrix
-    int *distmatrix = (int *)malloc(dim * dim * sizeof(int));
-    if (!distmatrix) fprintf(stderr, "malloc failed - distmatrix\n");
+        // free mmap, close file
+        munmap(distmatrixmap, (dim * dim + 1) * sizeof(int));
+        close(fd);
+    } else { 
+        // Parse the adjacency matrix
+        int *adjmatrix = parse_graph_file(&dim, &num_edges, tmpchar);
+        
+        // Initialize the distance matrix
+        distmatrix = (int *)malloc(dim * dim * sizeof(int));
+        if (!distmatrix) fprintf(stderr, "malloc failed - distmatrix\n");
 
-    // Initialize the result matrix
-    int *result = (int *)malloc(dim * dim * sizeof(int));
-    if (!result) fprintf(stderr, "malloc failed - result\n");
-
-    // TODO: Now only supports integer weights
-    // Setup the input matrix
-    for (int i = 0 ; i < dim; i++) {
-        for (int j = 0 ; j < dim; j++) {
-            if (i == j) {
-                // Diagonal
-                distmatrix[i * dim + j] = 0;
-            } else if (adjmatrix[i * dim + j] == -1) {
-                // Without edge
-                distmatrix[i * dim + j] = BIGNUM;
-            } else {
-                // With edge
-                distmatrix[i * dim + j] = adjmatrix[i * dim + j];
+        // TODO: Now only supports integer weights
+        // Setup the input matrix
+        for (int i = 0 ; i < dim; i++) {
+            for (int j = 0 ; j < dim; j++) {
+                if (i == j) {
+                    // Diagonal
+                    distmatrix[i * dim + j] = 0;
+                } else if (adjmatrix[i * dim + j] == -1) {
+                    // Without edge
+                    distmatrix[i * dim + j] = BIGNUM;
+                } else {
+                    // With edge
+                    distmatrix[i * dim + j] = adjmatrix[i * dim + j];
+                }
             }
         }
-    }
+        if (create_mmap) { 
+            printf("creating an mmap\n");
+            
+            // Prints distmatrix to file
+            std::ofstream fout("mmap.bin", std::ios::binary);
+            fout.write((char *)&dim, sizeof(int));
+            fout.write((char *)distmatrix, dim * dim * sizeof(int));
+            
+            free(distmatrix);
+            free(adjmatrix);
+            fout.close();
+            printf("mmap.bin created!\n");
+            return 0;
+        }
+        free(adjmatrix);
+    }    
+    
+    // Initialize the result matrix
+    result = (int *)malloc(dim * dim * sizeof(int));
+    if (!result) fprintf(stderr, "malloc failed - result\n");
 
     int *dist_d;
     int *next_d;
 
     // Create device-side FW buffers
-    err = hipMalloc(&dist_d, dim * dim * sizeof(int));
+    err = hipMallocManaged(&dist_d, dim * dim * sizeof(int));
     if (err != hipSuccess) {
         printf("ERROR: hipMalloc dist_d (size:%d) => %d\n",  dim * dim , err);
         return -1;
     }
-    err = hipMalloc(&next_d, dim * dim * sizeof(int));
+    err = hipMallocManaged(&next_d, dim * dim * sizeof(int));
     if (err != hipSuccess) {
         printf("ERROR: hipMalloc next_d (size:%d) => %d\n",  dim * dim , err);
         return -1;
@@ -165,7 +255,7 @@ int main(int argc, char **argv)
 
     // Work dimension
     dim3 threads(16, 16, 1);
-    dim3 grid(num_nodes / 16, num_nodes / 16, 1);
+    dim3 grid(dim / 16, dim / 16, 1);
 
     //double timer3 = gettime();
     // Main computation loop
@@ -225,7 +315,6 @@ int main(int argc, char **argv)
     printf("Finishing Floyd-Warshall\n");
 
     // Free host-side buffers
-    free(adjmatrix);
     free(result);
     free(distmatrix);
 

--- a/src/gpu/pannotia/fw/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/fw/Makefile.gem5-fusion
@@ -3,9 +3,9 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 
 # these are needed for m5ops
 # TODO: Need some sort of explicit PATH?  Read in?
-GEM5_PATH ?= /nobackup/sinclair/gem5
-CFLAGS += -I$(GEM5_PATH)/include
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+GEM5_ROOT ?= $(GEM5_ROOT)
+CFLAGS += -I$(GEM5_ROOT)/include
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 BIN_DIR ?= ./bin
 

--- a/src/gpu/pannotia/fw/README.md
+++ b/src/gpu/pannotia/fw/README.md
@@ -19,7 +19,7 @@ To compile FW:
 
 ```
 cd src/gpu/pannotia/fw
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gem5-fusion; make default
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion; make default
 ```
 
 If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/fw/bin folder. FW can be run on a non-mmapped input file, used to generate an mmapped input file, or run on an mmapped input file. To run FW using an mmapped input file, you must generate it first. An input file can be reused until it is overwritten by another file generation.  
@@ -31,7 +31,7 @@ FW is a GPU application, which requires that gem5 is built with the GCN3_X86 (or
 ```
 git clone https://gem5.googlesource.com/public/gem5
 cd gem5
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
 ## Running FW on GCN3_X86/gem5.opt
@@ -42,7 +42,7 @@ docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gp
 
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m default"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m default"
 ```
 
 # Generate a mmapped input file
@@ -51,7 +51,7 @@ docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu
 
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu bash -c "./gem5-resources/src/gpu/pannotia/fw/bin/fw_hip -f ./gem5-resources/src/gpu/pannotia/fw/1k_128k.gr -m generate"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu bash -c "./gem5-resources/src/gpu/pannotia/fw/bin/fw_hip -f ./gem5-resources/src/gpu/pannotia/fw/1k_128k.gr -m generate"
 ```
 
 # Run FW using a mmapped input file
@@ -59,7 +59,7 @@ docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu
 To run FW using an mmapped input file, you must generate it first. An input file can be reused until it is overwritten by another file generation.  
 
 ```
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m usemmap"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m usemmap"
 ```
                   
 Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/fw/1k_128k.gr>), as this is the smallest input that can be run with FW.  Note that 1k_128k is not designed for FW specifically though -- the above link has larger graphs designed to run with FW that you should consider using for larger experiments.

--- a/src/gpu/pannotia/fw/README.md
+++ b/src/gpu/pannotia/fw/README.md
@@ -9,24 +9,16 @@ shortdoc: >
     Resources to build a disk image with the GCN3 Pannotia FW workload.
 ---
 
-Floyd-Warshall (FW) is a graph analytics application that is part of the Pannotia benchmark suite.  It is a classical dynamic-programming algorithm designed to solve the all-pairs shortest path (APSP) problem.  The provided version is for use with the gpu-compute model of gem5.  Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
+Floyd-Warshall (FW) is a graph analytics application that is part of the Pannotia benchmark suite.
+It is a classical dynamic-programming algorithm designed to solve the all-pairs shortest path (APSP) problem.
+The provided version is for use with the gpu-compute model of gem5.  Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
 
 Compiling FW, compiling the GCN3_X86/Vega_X86 versions of gem5, and running FW on gem5 is dependent on the gcn-gpu docker image, `util/dockerfiles/gcn-gpu/Dockerfile` on the [gem5 stable branch](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable).
 
-## Compilation and Running
-
-To compile FW:
-
-```
-cd src/gpu/pannotia/fw
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion; make default
-```
-
-If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/fw/bin folder. FW can be run on a non-mmapped input file, used to generate an mmapped input file, or run on an mmapped input file. To run FW using an mmapped input file, you must generate it first. An input file can be reused until it is overwritten by another file generation.  
-
 ## Compiling GCN3_X86/gem5.opt
 
-FW is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.   The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
+FW is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.
+The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
 
 ```
 git clone https://gem5.googlesource.com/public/gem5
@@ -34,35 +26,56 @@ cd gem5
 docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
-## Running FW on GCN3_X86/gem5.opt
+## Compiling FW
+The Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).
 
-# Assuming gem5 and gem5-resources are in your working directory
+The docker command needs visibility to the gem5 repository for usage of the m5ops.
+Thus we run the docker command from a directory with visibility and cd into the folder before running the make command.  
+  
+Note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile)  
+  
+To compile FW assuming the gem5 and gem5-resources repositories are in your working directory:
 
-# Run FW without using a mmapped input file
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/fw ; make gem5-fusion"
+```
+
+If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.
+By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/fw/bin folder.
+FW can be run on a non-mmapped input file, used to generate an mmapped input file, or run on an mmapped input file.
+To run FW using an mmapped input file, you must generate it first. An input file can be reused until it is overwritten by another file generation.  
+
+# Running FW on GCN3_X86/gem5.opt
+
+## Run FW without using a mmapped input file
+
+Assuming gem5 and gem5-resources are in your working directory
 
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m default"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m default"
 ```
 
-# Generate a mmapped input file
+## Generate a mmapped input file
 
-# We recommend running mmap generation on the actual CPU instead of simulating it.
+We recommend running mmap generation on the actual CPU instead of simulating it.
 
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu bash -c "./gem5-resources/src/gpu/pannotia/fw/bin/fw_hip -f ./gem5-resources/src/gpu/pannotia/fw/1k_128k.gr -m generate"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "./gem5-resources/src/gpu/pannotia/fw/bin/fw_hip -f ./gem5-resources/src/gpu/pannotia/fw/1k_128k.gr -m generate"
 ```
 
-# Run FW using a mmapped input file
+## Run FW using a mmapped input file
 
 To run FW using an mmapped input file, you must generate it first. An input file can be reused until it is overwritten by another file generation.  
 
 ```
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m usemmap"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m usemmap"
 ```
                   
-Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/fw/1k_128k.gr>), as this is the smallest input that can be run with FW.  Note that 1k_128k is not designed for FW specifically though -- the above link has larger graphs designed to run with FW that you should consider using for larger experiments.
+Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.
+We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/fw/1k_128k.gr>), as this is the smallest input that can be run with FW.
+Note that 1k_128k is not designed for FW specifically though -- the above link has larger graphs designed to run with FW that you should consider using for larger experiments.
 
 ## Pre-built binary
 

--- a/src/gpu/pannotia/fw/README.md
+++ b/src/gpu/pannotia/fw/README.md
@@ -19,10 +19,10 @@ To compile FW:
 
 ```
 cd src/gpu/pannotia/fw
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gem5-fusion
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gem5-fusion; make default
 ```
 
-If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/fw/bin folder.
+If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/fw/bin folder. FW can be run on a non-mmapped input file, used to generate an mmapped input file, or run on an mmapped input file. To run FW using an mmapped input file, you must generate it first. An input file can be reused until it is overwritten by another file generation.  
 
 ## Compiling GCN3_X86/gem5.opt
 
@@ -37,11 +37,31 @@ docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gp
 ## Running FW on GCN3_X86/gem5.opt
 
 # Assuming gem5 and gem5-resources are in your working directory
+
+# Run FW without using a mmapped input file
+
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="1k_128k.gr"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m default"
 ```
 
+# Generate a mmapped input file
+
+# We recommend running mmap generation on the actual CPU instead of simulating it.
+
+```
+wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu bash -c "./gem5-resources/src/gpu/pannotia/fw/bin/fw_hip -f ./gem5-resources/src/gpu/pannotia/fw/1k_128k.gr -m generate"
+```
+
+# Run FW using a mmapped input file
+
+To run FW using an mmapped input file, you must generate it first. An input file can be reused until it is overwritten by another file generation.  
+
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/fw/bin -c fw_hip.gem5 --options="-f 1k_128k.gr -m usemmap"
+```
+                  
 Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/fw/1k_128k.gr>), as this is the smallest input that can be run with FW.  Note that 1k_128k is not designed for FW specifically though -- the above link has larger graphs designed to run with FW that you should consider using for larger experiments.
 
 ## Pre-built binary

--- a/src/gpu/pannotia/mis/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/mis/Makefile.gem5-fusion
@@ -6,9 +6,9 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 
 # these are needed for m5ops
 # TODO: Need some sort of explicit PATH?  Read in?
-GEM5_PATH ?= /nobackup/sinclair/gem5
-CFLAGS += -I$(GEM5_PATH)/include -I../graph_parser
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+GEM5_ROOT ?= /path/to/gem5
+CFLAGS += -I$(GEM5_ROOT)/include -I../graph_parser
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 BIN_DIR ?= ./bin
 

--- a/src/gpu/pannotia/mis/README.md
+++ b/src/gpu/pannotia/mis/README.md
@@ -19,7 +19,7 @@ To compile MIS:
 
 ```
 cd src/gpu/pannotia/mis
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gem5-fusion
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
 ```
 
 If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/mis/bin folder.
@@ -31,7 +31,7 @@ MIS is a GPU application, which requires that gem5 is built with the GCN3_X86 (o
 ```
 git clone https://gem5.googlesource.com/public/gem5
 cd gem5
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
 ## Running MIS on GCN3_X86/gem5.opt
@@ -39,7 +39,7 @@ docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gp
 # Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/mis/bin -c mis.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/mis/bin -c mis.gem5 --options="1k_128k.gr 0"
 ```
 
 Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/mis/1k_128k.gr>), as this is the smallest input that can be run with MIS.  Note that 1k_128k is not designed for MIS specifically though -- the above link has larger graphs designed to run with MIS that you should consider using for larger experiments.

--- a/src/gpu/pannotia/mis/README.md
+++ b/src/gpu/pannotia/mis/README.md
@@ -9,40 +9,51 @@ shortdoc: >
     Resources to build a disk image with the GCN3 Pannotia MIS workload.
 ---
 
-Maximal Independent Set (mis) is a graph analytics application that is part of the Pannotia benchmark suite.  It is designed to find a maximal subset of vertices in a graph such that no two are adjacent.  The provided version is for use with the gpu-compute model of gem5.  Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
+Maximal Independent Set (mis) is a graph analytics application that is part of the Pannotia benchmark suite.
+It is designed to find a maximal subset of vertices in a graph such that no two are adjacent.
+The provided version is for use with the gpu-compute model of gem5.
+Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
 
 Compiling MIS, compiling the GCN3_X86/Vega_X86 versions of gem5, and running MIS on gem5 is dependent on the gcn-gpu docker image, `util/dockerfiles/gcn-gpu/Dockerfile` on the [gem5 stable branch](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable).
 
-## Compilation and Running
-
-To compile MIS:
-
-```
-cd src/gpu/pannotia/mis
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
-```
-
-If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/mis/bin folder.
-
 ## Compiling GCN3_X86/gem5.opt
 
-MIS is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.   The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
+MIS is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.
+The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
 
 ```
 git clone https://gem5.googlesource.com/public/gem5
 cd gem5
 docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
+## Compiling MIS
+The Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).
 
-## Running MIS on GCN3_X86/gem5.opt
+The docker command needs visibility to the gem5 repository for usage of the m5ops.
+Thus we run the docker command from a directory with visibility and cd into the folder before running the make command.   
+  
+Note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile)  
+  
+To compile MIS assuming the gem5 and gem5-resources repositories are in your working directory:
 
-# Assuming gem5 and gem5-resources are in your working directory
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/mis ; make gem5-fusion"
+```
+
+If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.
+By default, the Makefile builds for gfx801 and gfx803, and is placed in the src/gpu/pannotia/mis/bin folder.
+
+# Running MIS on GCN3_X86/gem5.opt
+
+## Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/mis/bin -c mis.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/mis/bin -c mis.gem5 --options="1k_128k.gr 0"
 ```
 
-Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/mis/1k_128k.gr>), as this is the smallest input that can be run with MIS.  Note that 1k_128k is not designed for MIS specifically though -- the above link has larger graphs designed to run with MIS that you should consider using for larger experiments.
+Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.
+We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/mis/1k_128k.gr>), as this is the smallest input that can be run with MIS.
+Note that 1k_128k is not designed for MIS specifically though -- the above link has larger graphs designed to run with MIS that you should consider using for larger experiments.
 
 ## Pre-built binary
 

--- a/src/gpu/pannotia/pagerank/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/pagerank/Makefile.gem5-fusion
@@ -4,9 +4,9 @@ OPTS = -O3
 
 # these are needed for m5ops
 # TODO: Need some sort of explicit PATH?  Read in?
-GEM5_PATH ?= /nobackup/sinclair/gem5
-CFLAGS += -I$(GEM5_PATH)/include -I/../graph_parser
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+GEM5_ROOT ?= /path/to/gem5
+CFLAGS += -I$(GEM5_ROOT)/include -I/../graph_parser
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 BASEEXE = pagerank
 VARIANT ?= DEFAULT

--- a/src/gpu/pannotia/pagerank/README.md
+++ b/src/gpu/pannotia/pagerank/README.md
@@ -19,14 +19,14 @@ PR has two variants: default and spmv.  To compile the "default" variant:
 
 ```
 cd src/gpu/pannotia/pagerank
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gem5-fusion
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
 ```
 
 To compile the "spmv" variant:
 
 ```
 cd src/gpu/pannotia/pagerank
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu bash -c "export VARIANT=SPMV ; make gem5-fusion"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu bash -c "export VARIANT=SPMV ; make gem5-fusion"
 ```
 
 If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/pagerank/bin folder.  Moreover, by default the VARIANT variable PageRank's Makefile assumes the csr variant is being used, hence why this variable does not need to be set for compiling it.
@@ -38,7 +38,7 @@ PageRank is a GPU application, which requires that gem5 is built with the GCN3_X
 ```
 git clone https://gem5.googlesource.com/public/gem5
 cd gem5
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
 ## Running PageRank on GCN3_X86/gem5.opt
@@ -48,7 +48,7 @@ The following command shows how to run the PageRank default version:
 # Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/pagerank/coAuthorsDBLP.graph
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank.gem5 --options="coAuthorsDBLP.graph 1"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank.gem5 --options="coAuthorsDBLP.graph 1"
 ```
 
 To run the PageRank spmv version:
@@ -56,7 +56,7 @@ To run the PageRank spmv version:
 # Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/pagerank/coAuthorsDBLP.graph
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank_spmv.gem5 --options="coAuthorsDBLP.graph 1"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank_spmv.gem5 --options="coAuthorsDBLP.graph 1"
 ```
 
 Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the coAuthorsDBLP input for PR.

--- a/src/gpu/pannotia/pagerank/README.md
+++ b/src/gpu/pannotia/pagerank/README.md
@@ -9,31 +9,17 @@ shortdoc: >
     Resources to build a disk image with the GCN3 Pannotia PageRank workload.
 ---
 
-PageRank (PR) is a graph analytics application that is part of the Pannotia benchmark suite.  It is an algorithm designed to calculate probability distributions representing the likelihood that a person randomly clicking on links arrives at any particular page.  The provided version is for use with the gpu-compute model of gem5.  Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
+PageRank (PR) is a graph analytics application that is part of the Pannotia benchmark suite.
+It is an algorithm designed to calculate probability distributions representing the likelihood that a person randomly clicking on links arrives at any particular page.
+The provided version is for use with the gpu-compute model of gem5.
+Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
 
 Compiling both PageRank variants, compiling the GCN3_X86/Vega_X86 versions of gem5, and running both PageRank variants on gem5 is dependent on the gcn-gpu docker image, `util/dockerfiles/gcn-gpu/Dockerfile` on the [gem5 stable branch](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable).
 
-## Compilation and Running
-
-PR has two variants: default and spmv.  To compile the "default" variant:
-
-```
-cd src/gpu/pannotia/pagerank
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
-```
-
-To compile the "spmv" variant:
-
-```
-cd src/gpu/pannotia/pagerank
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu bash -c "export VARIANT=SPMV ; make gem5-fusion"
-```
-
-If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/pagerank/bin folder.  Moreover, by default the VARIANT variable PageRank's Makefile assumes the csr variant is being used, hence why this variable does not need to be set for compiling it.
-
 ## Compiling GCN3_X86/gem5.opt
 
-PageRank is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.  The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
+PageRank is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.
+The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
 
 ```
 git clone https://gem5.googlesource.com/public/gem5
@@ -41,25 +27,50 @@ cd gem5
 docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
-## Running PageRank on GCN3_X86/gem5.opt
+## Compiling PageRank
+The Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).
+To compile m5ops view the README.md in the parent directory, pannotia.
 
+The docker command needs visibility to the gem5 repository for usage of the m5ops.
+Thus we run the docker command from a directory with visibility and cd into the folder before running the make command.  
+  
+Note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile)  
+
+PR has two variants: default and spmv.  To compile the "default" variant assuming the gem5 and gem5-resources repositories are in your working directory:
+
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/pagerank ; make gem5-fusion"
+```
+
+To compile the "spmv" variant:
+
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/pagerank ; export VARIANT=SPMV ; make gem5-fusion"
+```
+
+If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.
+By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/pagerank/bin folder.
+Moreover, by default the VARIANT variable PageRank's Makefile assumes the csr variant is being used, hence why this variable does not need to be set for compiling it.
+
+
+# Running PageRank on GCN3_X86/gem5.opt
+
+Assuming gem5 and gem5-resources are in your working directory.
 The following command shows how to run the PageRank default version:
-
-# Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/pagerank/coAuthorsDBLP.graph
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank.gem5 --options="coAuthorsDBLP.graph 1"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank.gem5 --options="coAuthorsDBLP.graph 1"
 ```
 
+Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory.
 To run the PageRank spmv version:
-
-# Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/pagerank/coAuthorsDBLP.graph
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank_spmv.gem5 --options="coAuthorsDBLP.graph 1"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/pagerank/bin -c pagerank_spmv.gem5 --options="coAuthorsDBLP.graph 1"
 ```
 
-Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the coAuthorsDBLP input for PR.
+Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.
+We recommend you start with the coAuthorsDBLP input for PR.
 
 ## Pre-built binary
 

--- a/src/gpu/pannotia/sssp/Makefile.gem5-fusion
+++ b/src/gpu/pannotia/sssp/Makefile.gem5-fusion
@@ -3,9 +3,9 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 
 # these are needed for m5ops
 # TODO: Need some sort of explicit PATH?  Read in?
-GEM5_PATH ?= /nobackup/sinclair/gem5
-CFLAGS += -I$(GEM5_PATH)/include -I../graph_parser
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+GEM5_ROOT ?= /path/to/gem5
+CFLAGS += -I$(GEM5_ROOT)/include -I../graph_parser
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 BASEEXE = sssp
 VARIANT ?= CSR

--- a/src/gpu/pannotia/sssp/README.md
+++ b/src/gpu/pannotia/sssp/README.md
@@ -9,31 +9,17 @@ shortdoc: >
     Resources to build a disk image with the GCN3 Pannotia SSSP workload.
 ---
 
-Single-Source Shortest Path (sssp) is a graph analytics application that is part of the Pannotia benchmark suite.  It is designed to calculate the shortest paths between the source vertex and all the other vertices in a graph.  The provided version is for use with the gpu-compute model of gem5.  Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
+Single-Source Shortest Path (sssp) is a graph analytics application that is part of the Pannotia benchmark suite.
+It is designed to calculate the shortest paths between the source vertex and all the other vertices in a graph.
+The provided version is for use with the gpu-compute model of gem5.
+Thus, it has been ported from the prior CUDA and OpenCL variants to HIP, and validated on a Vega-class AMD GPU.
 
 Compiling both SSSP variants, compiling the GCN3_X86/Vega_X86 versions of gem5, and running both SSSP variants on gem5 is dependent on the gcn-gpu docker image, `util/dockerfiles/gcn-gpu/Dockerfile` on the [gem5 stable branch](https://gem5.googlesource.com/public/gem5/+/refs/heads/stable).
 
-## Compilation and Running
-
-SSSP has two variants: csr and ell.  To compile the "csr" variant:
-
-```
-cd src/gpu/pannotia/sssp
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
-```
-
-To compile the "ell" variant:
-
-```
-cd src/gpu/pannotia/sssp
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu bash -c "export VARIANT=ELL ; make gem5-fusion"
-```
-
-If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/sssp/bin folder.  Moreover, by default the VARIANT variable SSSP's Makefile assumes the csr variant is being used, hence why this variable does not need to be set for compiling it.
-
 ## Compiling GCN3_X86/gem5.opt
 
-SSSP is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.  The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
+SSSP is a GPU application, which requires that gem5 is built with the GCN3_X86 (or Vega_X86, although this has been less heavily tested) architecture.
+The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docker image:
 
 ```
 git clone https://gem5.googlesource.com/public/gem5
@@ -41,25 +27,50 @@ cd gem5
 docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
-## Running SSSP on GCN3_X86/gem5.opt
+## Compiling SSSP
+The Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).
 
+The docker command needs visibility to the gem5 repository for usage of the m5ops.
+Thus we run the docker command from a directory with visibility and cd into the folder before running the make command.  
+  
+Note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile)  
+  
+SSSP has two variants: csr and ell.  To compile the "csr" variant assuming the gem5 and gem5-resources repositories are in your working directory:
+
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/sssp ; make gem5-fusion"
+```
+
+To compile the "ell" variant:
+
+```
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest bash -c "cd gem5-resources/src/gpu/pannotia/sssp ; export VARIANT=ELL ; make gem5-fusion"
+```
+
+If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.
+By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/sssp/bin folder.
+Moreover, by default the VARIANT variable SSSP's Makefile assumes the csr variant is being used, hence why this variable does not need to be set for compiling it.
+
+
+# Running SSSP on GCN3_X86/gem5.opt
+
+Assuming gem5 and gem5-resources are in your working directory.
 The following command shows how to run the SSSP csr version:
-
-# Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_csr.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_csr.gem5 --options="1k_128k.gr 0"
 ```
 
+Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory.
 To run the SSSP ell version:
-
-# Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_ell.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:latest gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_ell.gem5 --options="1k_128k.gr 0"
 ```
 
-Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input that can be run with SSSP.  Note that 1k_128k is not designed for SSSP specifically though -- the above link has larger graphs designed to run with SSSP that you should consider using for larger experiments.
+Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.
+We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input that can be run with SSSP.
+Note that 1k_128k is not designed for SSSP specifically though -- the above link has larger graphs designed to run with SSSP that you should consider using for larger experiments.
 
 ## Pre-built binary
 

--- a/src/gpu/pannotia/sssp/README.md
+++ b/src/gpu/pannotia/sssp/README.md
@@ -19,14 +19,14 @@ SSSP has two variants: csr and ell.  To compile the "csr" variant:
 
 ```
 cd src/gpu/pannotia/sssp
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu make gem5-fusion
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu make gem5-fusion
 ```
 
 To compile the "ell" variant:
 
 ```
 cd src/gpu/pannotia/sssp
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu bash -c "export VARIANT=ELL ; make gem5-fusion"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu bash -c "export VARIANT=ELL ; make gem5-fusion"
 ```
 
 If you use the Makefile.default file instead, the Makefile will generate code designed to run on the real GPU instead.  Moreover, note that Makefile.gem5-fusion requires you to set the GEM5_ROOT variable (either on the command line or by modifying the Makefile), because the Pannotia applications have been updated to use [m5ops](https://www.gem5.org/documentation/general_docs/m5ops/).  By default, for both variants the Makefile builds for gfx801 and gfx803, and the binaries are placed in the src/gpu/pannotia/sssp/bin folder.  Moreover, by default the VARIANT variable SSSP's Makefile assumes the csr variant is being used, hence why this variable does not need to be set for compiling it.
@@ -38,7 +38,7 @@ SSSP is a GPU application, which requires that gem5 is built with the GCN3_X86 (
 ```
 git clone https://gem5.googlesource.com/public/gem5
 cd gem5
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:latest scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
 ## Running SSSP on GCN3_X86/gem5.opt
@@ -48,7 +48,7 @@ The following command shows how to run the SSSP csr version:
 # Assuming gem5 and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_csr.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_csr.gem5 --options="1k_128k.gr 0"
 ```
 
 To run the SSSP ell version:
@@ -56,7 +56,7 @@ To run the SSSP ell version:
 # Assuming gem5, pannotia (input graphs, see below), and gem5-resources are in your working directory
 ```
 wget http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_ell.gem5 --options="1k_128k.gr 0"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --mem-size=8GB --benchmark-root=gem5-resources/src/gpu/pannotia/sssp/bin -c sssp_ell.gem5 --options="1k_128k.gr 0"
 ```
 
 Note that the datasets from the original Pannotia suite have been uploaded to: <http://dist.gem5.org/dist/develop/datasets/pannotia>.  We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/develop/datasets/pannotia/bc/1k_128k.gr>), as this is the smallest input that can be run with SSSP.  Note that 1k_128k is not designed for SSSP specifically though -- the above link has larger graphs designed to run with SSSP that you should consider using for larger experiments.

--- a/src/gpu/pennant/README.md
+++ b/src/gpu/pennant/README.md
@@ -20,7 +20,7 @@ a sample of the typical memory access patterns of FLAG.
 
 ```
 cd src/gpu/pennant
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 make
 ```
 
 By default, the binary is built for gfx801 and is placed in `src/gpu/pennant/build`
@@ -31,7 +31,7 @@ pennant has sample input files located at `src/gpu/pennant/test`. The following 
 
 ```
 # Assuming gem5 and gem5-resources are in your working directory
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --benchmark-root=gem5-resources/src/gpu/pennant/build -cpennant --options="gem5-resources/src/gpu/pennant/test/noh/noh.pnt"
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n3 --benchmark-root=gem5-resources/src/gpu/pennant/build -cpennant --options="gem5-resources/src/gpu/pennant/test/noh/noh.pnt"
 ```
 
 The output gets placed in `src/gpu/pennant/test/noh/`, and the file `noh.xy`

--- a/src/gpu/square/README.md
+++ b/src/gpu/square/README.md
@@ -18,7 +18,7 @@ Compiling square, compiling the GCN3_X86 gem5, and running square on gem5 is dep
 By default, square will build for all supported GPU types (gfx801, gfx803)
 ```
 cd src/gpu/square
-docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID gcr.io/gem5-test/gcn-gpu:v22-1 make
+docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v22-1 make
 ```
 
 The compiled binary can be found in the `bin` directory.
@@ -34,11 +34,11 @@ The test is run with the GCN3_X86 gem5 variant, compiled using the gcn-gpu docke
 ```
 git clone https://gem5.googlesource.com/public/gem5
 cd gem5
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:v22-1 scons build/GCN3_X86/gem5.opt -j <num cores>
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:v22-1 scons build/GCN3_X86/gem5.opt -j <num cores>
 ```
 
 ## Running Square on GCN3_X86/gem5.opt
 
 ```
-docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) gcr.io/gem5-test/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n 3 -c bin/square
+docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:v22-1 gem5/build/GCN3_X86/gem5.opt gem5/configs/example/apu_se.py -n 3 -c bin/square
 ```


### PR DESCRIPTION
The docker command for compiling pannotia tests needs to have visibility to m5ops.