### PR TITLE
resources: Fix hipDeviceSynchronize calls

### DIFF
--- a/src/gpu/pannotia/color/coloring_max.cpp
+++ b/src/gpu/pannotia/color/coloring_max.cpp
@@ -230,10 +230,12 @@ int main(int argc, char **argv)
         hipLaunchKernelGGL(HIP_KERNEL_NAME(color1), dim3(grid), dim3(threads ), 0, 0, row_d, col_d, node_value_d, color_d,
                                      stop_d, max_d, graph_color, num_nodes,
                                      num_edges);
+        hipDeviceSynchronize();
 
         // Launch the color kernel 2
         hipLaunchKernelGGL(HIP_KERNEL_NAME(color2), dim3(grid), dim3(threads ), 0, 0, node_value_d, color_d, max_d, graph_color,
                                      num_nodes, num_edges);
+        hipDeviceSynchronize();
 
         err = hipMemcpy(&stop, stop_d, sizeof(int), hipMemcpyDeviceToHost);
         if (err != hipSuccess) {
@@ -244,7 +246,6 @@ int main(int argc, char **argv)
         graph_color++;
 
     }
-    hipDeviceSynchronize();
 
 //    double timer4 = gettime();
 

--- a/src/gpu/pannotia/color/coloring_maxmin.cpp
+++ b/src/gpu/pannotia/color/coloring_maxmin.cpp
@@ -215,6 +215,7 @@ int main(int argc, char **argv)
 
     // Initialize arrays
     hipLaunchKernelGGL(ini, dim3(grid), dim3(threads ), 0, 0, max_d, min_d, num_nodes);
+    hipDeviceSynchronize();
 
     // Main computation loop
     double timer3 = gettime();
@@ -233,10 +234,12 @@ int main(int argc, char **argv)
         hipLaunchKernelGGL(color1, dim3(grid), dim3(threads ), 0, 0, row_d, col_d, node_value_d, color_d,
                                      stop_d, max_d, min_d, graph_color,
                                      num_nodes, num_edges);
+        hipDeviceSynchronize();
 
         // Launch the color kernel 2
         hipLaunchKernelGGL(color2, dim3(grid), dim3(threads ), 0, 0, node_value_d, color_d, max_d, min_d,
                                      graph_color, num_nodes, num_edges);
+        hipDeviceSynchronize();
 
         err = hipMemcpy(&stop, stop_d, sizeof(int), hipMemcpyDeviceToHost);
         if (err != hipSuccess) {
@@ -247,7 +250,6 @@ int main(int argc, char **argv)
         graph_color = graph_color + 2;
 
     }
-    hipDeviceSynchronize();
 
     double timer4 = gettime();
 

--- a/src/gpu/pannotia/mis/mis.cpp
+++ b/src/gpu/pannotia/mis/mis.cpp
@@ -241,14 +241,17 @@ int main(int argc, char **argv)
         hipLaunchKernelGGL(HIP_KERNEL_NAME(mis1), dim3(grid), dim3(threads), 0, 0, row_d, col_d, node_value_d, s_array_d,
                                  c_array_d, min_array_d, stop_d, num_nodes,
                                  num_edges);
+        hipDeviceSynchronize();
 
         // Launch mis2
         hipLaunchKernelGGL(HIP_KERNEL_NAME(mis2), dim3(grid), dim3(threads), 0, 0, row_d, col_d, node_value_d, s_array_d,
                                  c_array_d, c_array_u_d, min_array_d, num_nodes,
                                  num_edges);
+        hipDeviceSynchronize();
 
         // Launch mis3
         hipLaunchKernelGGL(HIP_KERNEL_NAME(mis3), dim3(grid), dim3(threads), 0, 0, c_array_u_d, c_array_d, num_nodes);
+        hipDeviceSynchronize();
 
         // Copy the termination variable back
         err = hipMemcpy(&stop, stop_d, sizeof(int), hipMemcpyDeviceToHost);
@@ -259,8 +262,6 @@ int main(int argc, char **argv)
 
         iterations++;
     }
-
-    hipDeviceSynchronize();
 
     err = hipMemcpy(s_array, s_array_d, num_nodes * sizeof(int), hipMemcpyDeviceToHost);
     if (err != hipSuccess) {

--- a/src/gpu/pannotia/pagerank/pagerank.cpp
+++ b/src/gpu/pannotia/pagerank/pagerank.cpp
@@ -198,12 +198,13 @@ int main(int argc, char **argv)
         // Launch pagerank kernel 1
         hipLaunchKernelGGL(HIP_KERNEL_NAME(pagerank1), dim3(grid), dim3(threads), 0, 0, row_d, col_d, data_d, pagerank1_d,
                                       pagerank2_d, num_nodes, num_edges);
+        hipDeviceSynchronize();
 
         // Launch pagerank kernel 2
         hipLaunchKernelGGL(HIP_KERNEL_NAME(pagerank2), dim3(grid), dim3(threads), 0, 0, row_d, col_d, data_d, pagerank1_d,
                                       pagerank2_d, num_nodes, num_edges);
+        hipDeviceSynchronize();
     }
-    hipDeviceSynchronize();
 
 //    double timer4 = gettime();
 

--- a/src/gpu/pannotia/pagerank/pagerank_spmv.cpp
+++ b/src/gpu/pannotia/pagerank/pagerank_spmv.cpp
@@ -214,11 +214,12 @@ int main(int argc, char **argv)
         hipLaunchKernelGGL(spmv_csr_scalar_kernel, dim3(grid), dim3(threads), 0, 0, num_nodes, row_d, col_d,
                                                    data_d, pagerank1_d,
                                                    pagerank2_d);
+        hipDeviceSynchronize();
 
         // Launch pagerank kernel 2
         hipLaunchKernelGGL(pagerank2, dim3(grid), dim3(threads), 0, 0, pagerank1_d, pagerank2_d, num_nodes);
+        hipDeviceSynchronize();
     }
-    hipDeviceSynchronize();
 
     double timer4 = gettime();
 

--- a/src/gpu/pannotia/sssp/sssp_csr.cpp
+++ b/src/gpu/pannotia/sssp/sssp_csr.cpp
@@ -220,15 +220,18 @@ int main(int argc, char **argv)
 
         // Launch the assignment kernel
         hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_assign), dim3(grid), dim3(threads), 0, 0, vector_d1, vector_d2, num_nodes);
+        hipDeviceSynchronize();
 
         // Launch the min.+ kernel
         hipLaunchKernelGGL(HIP_KERNEL_NAME(spmv_min_dot_plus_kernel), dim3(grid), dim3(threads), 0, 0, num_nodes, row_d, col_d,
                                                      data_d, vector_d1,
                                                      vector_d2);
+        hipDeviceSynchronize();
 
         // Launch the check kernel
         hipLaunchKernelGGL(HIP_KERNEL_NAME(vector_diff), dim3(grid), dim3(threads), 0, 0, vector_d1, vector_d2,
                                         stop_d, num_nodes);
+        hipDeviceSynchronize();
 
         // Read the termination variable back
         err = hipMemcpy(&stop, stop_d, sizeof(int), hipMemcpyDeviceToHost);
@@ -243,7 +246,6 @@ int main(int argc, char **argv)
         }
         cnt++;
     }
-    hipDeviceSynchronize();
     //double timer4 = gettime();
 
     // Read the cost_array back

--- a/src/gpu/pannotia/sssp/sssp_ell.cpp
+++ b/src/gpu/pannotia/sssp/sssp_ell.cpp
@@ -217,15 +217,18 @@ int main(int argc, char **argv)
 
         // Launch the assignment kernel
         hipLaunchKernelGGL(vector_assign, dim3(grid), dim3(threads), 0, 0, vector_d1, vector_d2, num_nodes);
+        hipDeviceSynchronize();
 
         // Launch the min.+ kernel
         hipLaunchKernelGGL(ell_min_dot_plus_kernel, dim3(grid), dim3(threads), 0, 0, num_nodes, height,
                                                     ell_col_d, ell_data_d,
                                                     vector_d1, vector_d2);
+        hipDeviceSynchronize();
 
         // Launch the check kernel
         hipLaunchKernelGGL(vector_diff, dim3(grid), dim3(threads), 0, 0, vector_d1, vector_d2,
                                         stop_d, num_nodes);
+        hipDeviceSynchronize();
 
         // Read the termination variable back
         err = hipMemcpy(&stop, stop_d, sizeof(int), hipMemcpyDeviceToHost);
@@ -240,7 +243,6 @@ int main(int argc, char **argv)
         }
         cnt++;
     }
-    hipDeviceSynchronize();
     double timer4 = gettime();
 
     // Read the cost_array back


### PR DESCRIPTION
Corrected hipDeviceSynchronize calls to prevent kernels from exiting prematurely

Change-Id: I068b6324f33d0de905477d03efa195e3068dc7c5