### PR TITLE
resources: Move GPUFS hcl packages, PyTorch 2.3.0

### DIFF
--- a/src/x86-ubuntu-gpu-ml/README.md
+++ b/src/x86-ubuntu-gpu-ml/README.md
@@ -21,7 +21,7 @@ Details of the disk contents are:
     - [HIP](https://github.com/ROCm/HIP): hipcc LLVM compiler and HIP versions of roc libraries.
     - roc Libraries: rocBLAS, rocSPARSE, rocgdb, etc.
     - MI libraries: MIOpen, MIGraphX, etc.
-- [PyTorch](https://pytorch.org/) 2.2.2: PyTorch is a machine learning library based on the Torch library
+- [PyTorch](https://pytorch.org/) 2.3.0: PyTorch is a machine learning library based on the Torch library
 - [TensorFlow](https://tensorflow.org/) 2.14: a free and open-source software library for machine learning and artificial intelligence.
     - The python package tensorflow_datasets is also installed for convenience as these are used in the first TensorFlow tutorials.
 

--- a/src/x86-ubuntu-gpu-ml/http/user-data
+++ b/src/x86-ubuntu-gpu-ml/http/user-data
@@ -12,11 +12,6 @@ autoinstall:
     - arches:
       - default
       uri: http://ports.ubuntu.com/ubuntu-ports
-  packages:
-  - build-essential
-  - git
-  - scons
-  - vim
   drivers:
     install: false
   identity:

--- a/src/x86-ubuntu-gpu-ml/scripts/rocm-install.sh
+++ b/src/x86-ubuntu-gpu-ml/scripts/rocm-install.sh
@@ -7,6 +7,16 @@
 # All rights reserved.
 # SPDX-License-Identifier: BSD 3-Clause
 
+# Installing the packages in this script instead of the user-data
+# file dueing ubuntu autoinstall. The reason is that sometimes
+# the package install failes. This method is more reliable.
+echo 'installing packages'
+apt-get update
+apt-get install -y scons
+apt-get install -y git
+apt-get install -y vim
+apt-get install -y build-essential
+
 # Remove the motd
 rm /etc/update-motd.d/*
 
@@ -68,12 +78,12 @@ sudo chmod 777 /root/roms
 
 
 # See https://pytorch.org/ . At the time of writing the selector was:
-# Build: 2.2.2
+# Build: 2.3.0
 # OS: Linux
 # Package: Pip
 # Language: Python
-# Compute Platfrom: ROCm 5.7 (Note: This is currently the latest ROCm supported)
-pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm5.7
+# Compute Platfrom: ROCm 6.0 (Note: Latest ROCm when this file was last modified)
+pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.0
 
 # See https://pypi.org/project/tensorflow-rocm/#description
 # Datasets are also installed as gem5 has no internet connection.


### PR DESCRIPTION
Move the packages from http/user-data to the install script similar to
(https://github.com/gem5/gem5-resources/pull/31). Bump PyTorch to version 2.3.0. This is the first version to
support MI300. An MI300 config should be released with v24.0.