### PR TITLE
resources: add build option to build riscv 24.04 image.

### DIFF
--- a/src/riscv-ubuntu-22.04/build.sh
+++ b/src/riscv-ubuntu-22.04/build.sh
@@ -11,12 +11,28 @@ if [ ! -f ./packer ]; then
     rm packer_${PACKER_VERSION}_linux_amd64.zip;
 fi
 
+# Check if the Ubuntu version variable is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <ubuntu_version>"
+    echo "Example: $0 22.04 or $0 24.04"
+    exit 1
+fi
 
-wget https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz
-unxz ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz
+ubuntu_version="$1"
+
+if [[ "$ubuntu_version" == "22.04" ]]; then
+    wget https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz
+    unxz ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz
+fi
+
+if [[ "$ubuntu_version" == "24.04" ]]; then
+    wget https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64.img.xz
+    unxz ubuntu-24.04-preinstalled-server-riscv64.img.xz
+fi
+
 
 # Install the needed plugins
 ./packer init riscv-ubuntu.pkr.hcl
 
 # Build the image
-./packer build riscv-ubuntu.pkr.hcl
+./packer build -var "ubuntu_version=${ubuntu_version}" riscv-ubuntu.pkr.hcl


### PR DESCRIPTION
- This change also removes http directory as we are not using it.