### PR TITLE
resources: Update pannotia Makefiles for GPUFS/HW

### DIFF
--- a/src/gpu/pannotia/bc/Makefile.default
+++ b/src/gpu/pannotia/bc/Makefile.default
@@ -11,7 +11,7 @@ BIN_DIR ?= ./bin.default
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): $(CPPSRC) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp $(CPPSRC) -o $(BIN_DIR)/$(EXECUTABLE)
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(CPPSRC) -o $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/bc/Makefile.gpufs
+++ b/src/gpu/pannotia/bc/Makefile.gpufs
@@ -4,10 +4,13 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 EXECUTABLE = bc_hip.gpufs
 CPPSRC = BC.cpp 
 
+# Assumes gem5 and gem5-resources share a common parent directory.
+GEM5_ROOT ?= ../../../../../gem5
+
 # BC has a runtime error in fgets with -O2 and -O3
-OPTS = -O1 -Wno-unused-result -DGEM5_FS -I$(GEM5_PATH)/include -I$(GEM5_PATH)
+OPTS = -O1 -Wno-unused-result -DGEM5_FS -I$(GEM5_ROOT)/include -I$(GEM5_ROOT)
 BIN_DIR ?= ./bin.gpufs
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 all: $(BIN_DIR)/$(EXECUTABLE)
 

--- a/src/gpu/pannotia/color/Makefile.default
+++ b/src/gpu/pannotia/color/Makefile.default
@@ -7,17 +7,22 @@ MAXMIN_EXE = color_maxmin.default
 MAX_CPP = coloring_max.cpp
 MAXMIN_CPP = coloring_maxmin.cpp
 
-CPPSRC = ../graph_parser/util.cpp ../graph_parser/parse.cpp
 OPTS = -O3 -Wno-unused-result
 BIN_DIR ?= ./bin.default
 
 all: $(BIN_DIR)/$(MAX_EXE) $(BIN_DIR)/$(MAXMIN_EXE)
 
 $(BIN_DIR)/$(MAX_EXE): $(MAX_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(MAX_CPP) $(CPPSRC) -o $(BIN_DIR)/$(MAX_EXE)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(MAX_CPP) -o $(BIN_DIR)/$(MAX_EXE)
 
 $(BIN_DIR)/$(MAXMIN_EXE): $(MAXMIN_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(MAXMIN_CPP) $(CPPSRC) -o $(BIN_DIR)/$(MAXMIN_EXE)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(MAXMIN_CPP) -o $(BIN_DIR)/$(MAXMIN_EXE)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/color/Makefile.gpufs
+++ b/src/gpu/pannotia/color/Makefile.gpufs
@@ -7,18 +7,26 @@ MAXMIN_EXE = color_maxmin.gpufs
 MAX_CPP = coloring_max.cpp
 MAXMIN_CPP = coloring_maxmin.cpp
 
-CPPSRC = ../graph_parser/util.cpp ../graph_parser/parse.cpp
-OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_PATH)/include -I$(GEM5_PATH)
+# Assumes gem5 and gem5-resources share a common parent directory.
+GEM5_ROOT ?= ../../../../../gem5
+
+OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_ROOT)/include -I$(GEM5_ROOT)
 BIN_DIR ?= ./bin.gpufs
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 all: $(BIN_DIR)/$(MAX_EXE) $(BIN_DIR)/$(MAXMIN_EXE)
 
 $(BIN_DIR)/$(MAX_EXE): $(MAX_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(MAX_CPP) $(CPPSRC) -o $(BIN_DIR)/$(MAX_EXE) $(LDFLAGS)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(MAX_CPP) -o $(BIN_DIR)/$(MAX_EXE) $(LDFLAGS)
 
 $(BIN_DIR)/$(MAXMIN_EXE): $(MAXMIN_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(MAXMIN_CPP) $(CPPSRC) -o $(BIN_DIR)/$(MAXMIN_EXE) $(LDFLAGS)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(MAXMIN_CPP) -o $(BIN_DIR)/$(MAXMIN_EXE) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/fw/Makefile.gpufs
+++ b/src/gpu/pannotia/fw/Makefile.gpufs
@@ -4,9 +4,12 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 EXECUTABLE = fw_hip.gpufs
 CPPSRC = Floyd-Warshall.cpp
 
-OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_PATH)/include -I$(GEM5_PATH)
+# Assumes gem5 and gem5-resources share a common parent directory.
+GEM5_ROOT ?= ../../../../../gem5
+
+OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_ROOT)/include -I$(GEM5_ROOT)
 BIN_DIR ?= ./bin.gpufs
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 all: $(BIN_DIR)/$(EXECUTABLE)
 

--- a/src/gpu/pannotia/mis/Makefile.default
+++ b/src/gpu/pannotia/mis/Makefile.default
@@ -10,7 +10,10 @@ BIN_DIR ?= ./bin.default
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): $(CPPSRC) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(CPPSRC) -o $(BIN_DIR)/$(EXECUTABLE)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(CPPSRC) -o $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/mis/Makefile.gpufs
+++ b/src/gpu/pannotia/mis/Makefile.gpufs
@@ -4,14 +4,19 @@ HIPCC = $(HIP_PATH)/bin/hipcc
 EXECUTABLE = mis_hip.gpufs
 CPPSRC = mis.cpp
 
-OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_PATH)/include -I$(GEM5_PATH)
+# Assumes gem5 and gem5-resources share a common parent directory.
+GEM5_ROOT ?= ../../../../../gem5
+
+OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_ROOT)/include -I$(GEM5_ROOT)
 BIN_DIR ?= ./bin.gpufs
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 all: $(BIN_DIR)/$(EXECUTABLE)
 
 $(BIN_DIR)/$(EXECUTABLE): $(CPPSRC) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(CPPSRC) -o $(BIN_DIR)/$(EXECUTABLE) $(LDFLAGS)
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(CPPSRC) -o $(BIN_DIR)/$(EXECUTABLE) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/pagerank/Makefile.default
+++ b/src/gpu/pannotia/pagerank/Makefile.default
@@ -7,17 +7,22 @@ SPMV_EXE = pagerank_spmv.default
 DEF_CPP = pagerank.cpp
 SPMV_CPP = pagerank_spmv.cpp
 
-CPPSRC = ../graph_parser/util.cpp ../graph_parser/parse.cpp
 OPTS = -O3 -Wno-unused-result
 BIN_DIR ?= ./bin.default
 
 all: $(BIN_DIR)/$(DEF_EXE) $(BIN_DIR)/$(SPMV_EXE)
 
 $(BIN_DIR)/$(DEF_EXE): $(DEF_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(DEF_CPP) $(CPPSRC) -o $(BIN_DIR)/$(DEF_EXE)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(DEF_CPP) -o $(BIN_DIR)/$(DEF_EXE)
 
 $(BIN_DIR)/$(SPMV_EXE): $(SPMV_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(SPMV_CPP) $(CPPSRC) -o $(BIN_DIR)/$(SPMV_EXE)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(SPMV_CPP) -o $(BIN_DIR)/$(SPMV_EXE)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/pagerank/Makefile.gpufs
+++ b/src/gpu/pannotia/pagerank/Makefile.gpufs
@@ -7,18 +7,26 @@ SPMV_EXE = pagerank_spmv.gpufs
 DEF_CPP = pagerank.cpp
 SPMV_CPP = pagerank_spmv.cpp
 
-CPPSRC = ../graph_parser/util.cpp ../graph_parser/parse.cpp
-OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_PATH)/include -I$(GEM5_PATH)
+# Assumes gem5 and gem5-resources share a common parent directory.
+GEM5_ROOT ?= ../../../../../gem5
+
+OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_ROOT)/include -I$(GEM5_ROOT)
 BIN_DIR ?= ./bin.gpufs
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 all: $(BIN_DIR)/$(DEF_EXE) $(BIN_DIR)/$(SPMV_EXE)
 
 $(BIN_DIR)/$(DEF_EXE): $(DEF_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(DEF_CPP) $(CPPSRC) -o $(BIN_DIR)/$(DEF_EXE) $(LDFLAGS)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(DEF_CPP) -o $(BIN_DIR)/$(DEF_EXE) $(LDFLAGS)
 
 $(BIN_DIR)/$(SPMV_EXE): $(SPMV_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(SPMV_CPP) $(CPPSRC) -o $(BIN_DIR)/$(SPMV_EXE) $(LDFLAGS)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(SPMV_CPP) -o $(BIN_DIR)/$(SPMV_EXE) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/sssp/Makefile.default
+++ b/src/gpu/pannotia/sssp/Makefile.default
@@ -7,17 +7,22 @@ ELL_EXE = sssp_ell.default
 CSR_CPP = sssp_csr.cpp
 ELL_CPP = sssp_ell.cpp
 
-CPPSRC = ../graph_parser/util.cpp ../graph_parser/parse.cpp
 OPTS = -O3 -Wno-unused-result
 BIN_DIR ?= ./bin.default
 
 all: $(BIN_DIR)/$(CSR_EXE) $(BIN_DIR)/$(ELL_EXE)
 
 $(BIN_DIR)/$(CSR_EXE): $(CSR_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(CSR_CPP) $(CPPSRC) -o $(BIN_DIR)/$(CSR_EXE)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(CSR_CPP) -o $(BIN_DIR)/$(CSR_EXE)
 
 $(BIN_DIR)/$(ELL_EXE): $(ELL_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(ELL_CPP) $(CPPSRC) -o $(BIN_DIR)/$(ELL_EXE)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(ELL_CPP) -o $(BIN_DIR)/$(ELL_EXE)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)

--- a/src/gpu/pannotia/sssp/Makefile.gpufs
+++ b/src/gpu/pannotia/sssp/Makefile.gpufs
@@ -7,18 +7,26 @@ ELL_EXE = sssp_ell.gpufs
 CSR_CPP = sssp_csr.cpp
 ELL_CPP = sssp_ell.cpp
 
-CPPSRC = ../graph_parser/util.cpp ../graph_parser/parse.cpp
-OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_PATH)/include -I$(GEM5_PATH)
+# Assumes gem5 and gem5-resources share a common parent directory.
+GEM5_ROOT ?= ../../../../../gem5
+
+OPTS = -O3 -Wno-unused-result -DGEM5_FS -I$(GEM5_ROOT)/include -I$(GEM5_ROOT)
 BIN_DIR ?= ./bin.gpufs
-LDFLAGS += -L$(GEM5_PATH)/util/m5/build/x86/out -lm5
+LDFLAGS += -L$(GEM5_ROOT)/util/m5/build/x86/out -lm5
 
 all: $(BIN_DIR)/$(CSR_EXE) $(BIN_DIR)/$(ELL_EXE)
 
 $(BIN_DIR)/$(CSR_EXE): $(CSR_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(CSR_CPP) $(CPPSRC) -o $(BIN_DIR)/$(CSR_EXE) $(LDFLAGS)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(CSR_CPP) -o $(BIN_DIR)/$(CSR_EXE) $(LDFLAGS)
 
 $(BIN_DIR)/$(ELL_EXE): $(ELL_CPP) ../graph_parser/parse.cpp ../graph_parser/util.cpp $(BIN_DIR)
-	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(ELL_CPP) $(CPPSRC) -o $(BIN_DIR)/$(ELL_EXE) $(LDFLAGS)
+	# There is a futex issue in hipcc with the graph parser. Compile without opts until this is fixed.
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/parse.cpp -o $(BIN_DIR)/parse.o -c
+	$(HIPCC) -O0 --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) ../graph_parser/util.cpp -o $(BIN_DIR)/util.o -c
+	$(HIPCC) $(OPTS) --offload-arch=gfx900,gfx90a,gfx942 $(CXXFLAGS) $(BIN_DIR)/parse.o $(BIN_DIR)/util.o $(ELL_CPP) -o $(BIN_DIR)/$(ELL_EXE) $(LDFLAGS)
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)


### PR DESCRIPTION
There is an issue with the compiler used with GPUFS and hardware that causes a hang or crash in fstream. PR #44 changed fstream to fopen as fstream has similar issues in ROCm 4.0. To compromise and support both versions, this PR updates the GPUFS and hardware (Makefile.default) Makefiles to build the input parser with optimizations off (-O0) which "solves" the issue. Since we typically do not care about simulation time of reading input files, this seems like a decent compromise.

The GPUFS Makefiles also change the GEM5_PATH environment variable to GEM5_ROOT to be consistent with each Makefile.gem5-fusion.

The BC application is unchanged as it implements its open parser in its header file which cannot be compiled to an object file without refactoring the benchmark.