### PR TITLE
DRAFT: resources: Add gem5_bridge driver to x86-ubuntu build & boot

### DIFF
--- a/src/arm-ubuntu/files/after_boot.sh
+++ b/src/arm-ubuntu/files/after_boot.sh
@@ -40,7 +40,7 @@ else
             # If we can't read the script exit the simulation. If we cannot exit the
             # simulation, this probably means that we are running in QEMU. So, ignore
             # future calls to gem5-bridge.
-            if ! gem5-bridge exit; then
+            if ! echo 0 > /dev/gem5/exit; then
                 # Useful for booting the disk image in (e.g.,) qemu for debugging
                 printf "gem5-bridge exit failed, dropping to shell.\n"
                 IGNORE_M5=1 /bin/bash

--- a/src/arm-ubuntu/files/gem5_init.sh
+++ b/src/arm-ubuntu/files/gem5_init.sh
@@ -7,9 +7,25 @@ mount -t sysfs /sys /sys
 cmdline=$(cat /proc/cmdline)
 no_systemd=false
 
+# Load gem5_bridge driver
+## Default parameters (ARM64)
+gem5_bridge_baseaddr=0x10010000
+gem5_bridge_rangesize=0x10000
+## Try to read overloads from kernel arguments
+if [[ $cmdline =~ gem5_bridge_baseaddr=([[:alnum:]]+) ]]; then
+    gem5_bridge_baseaddr=${BASH_REMATCH[1]}
+fi
+if [[ $cmdline =~ gem5_bridge_rangesize=([[:alnum:]]+) ]]; then
+    gem5_bridge_rangesize=${BASH_REMATCH[1]}
+fi
+## Insert driver
+modprobe gem5_bridge \
+    gem5_bridge_baseaddr=$gem5_bridge_baseaddr \
+    gem5_bridge_rangesize=$gem5_bridge_rangesize
+
 # gem5-bridge exit signifying that kernel is booted
 printf "Kernel booted, starting gem5 init...\n"
-gem5-bridge exit
+echo 0 > /dev/gem5/exit # TODO: Make this a specialized event.
 
 if [[ $cmdline == *"no_systemd"* ]]; then
     no_systemd=true
@@ -17,9 +33,9 @@ fi
 
 # Run systemd via exec if not disabled
 if [[ $no_systemd == false ]]; then
-    # gem5-bridge exit signifying that systemd will be booted
     printf "Starting systemd...\n"
     exec /lib/systemd/systemd
 else
+    printf "Dropping to shell as gem5 user...\n"
     exec su - gem5
 fi

--- a/src/x86-ubuntu/files/after_boot.sh
+++ b/src/x86-ubuntu/files/after_boot.sh
@@ -14,7 +14,7 @@
 
 # gem5-bridge exit signifying that after_boot.sh is running
 printf "In after_boot.sh...\n"
-echo 0 > /dev/gem5/exit # TODO: Make this a specialized event.
+gem5-bridge exit # TODO: Make this a specialized event.
 
 # Read /proc/cmdline and parse options
 
@@ -34,13 +34,13 @@ else
     # Try to read the file from the host when running with gem5
     if ! [ -z $IGNORE_M5 ]; then
         printf "Starting gem5 init... trying to read run script file via readfile.\n"
-        if ! cat /dev/gem5/readfile > /tmp/script; then
+        if ! gem5-bridge readfile > /tmp/script; then
             printf "Failed to run gem5-bridge readfile, exiting!\n"
             rm -f /tmp/script
             # If we can't read the script exit the simulation. If we cannot exit the
             # simulation, this probably means that we are running in QEMU. So, ignore
             # future calls to gem5-bridge.
-            if ! echo 0 > /dev/gem5/exit; then
+            if ! gem5-bridge exit; then
                 # Useful for booting the disk image in (e.g.,) qemu for debugging
                 printf "gem5-bridge exit failed, dropping to shell.\n"
                 IGNORE_M5=1 /bin/bash
@@ -51,7 +51,7 @@ else
             /tmp/script
             printf "Done running script from gem5-bridge, exiting.\n"
             rm -f /tmp/script
-            echo 0 > /dev/gem5/exit
+            gem5-bridge exit
         fi
     fi
 fi

--- a/src/x86-ubuntu/files/after_boot.sh
+++ b/src/x86-ubuntu/files/after_boot.sh
@@ -14,7 +14,7 @@
 
 # gem5-bridge exit signifying that after_boot.sh is running
 printf "In after_boot.sh...\n"
-gem5-bridge exit # TODO: Make this a specialized event.
+echo 0 > /dev/gem5/exit # TODO: Make this a specialized event.
 
 # Read /proc/cmdline and parse options
 
@@ -28,19 +28,19 @@ fi
 printf "Interactive mode: $interactive\n"
 
 if [[ $interactive == true ]]; then
-    printf "Interactive mode enabled, dropping to shell."
+    printf "Interactive mode enabled, dropping to shell.\n"
     /bin/bash
 else
     # Try to read the file from the host when running with gem5
     if ! [ -z $IGNORE_M5 ]; then
         printf "Starting gem5 init... trying to read run script file via readfile.\n"
-        if ! gem5-bridge readfile > /tmp/script; then
+        if ! cat /dev/gem5/readfile > /tmp/script; then
             printf "Failed to run gem5-bridge readfile, exiting!\n"
             rm -f /tmp/script
             # If we can't read the script exit the simulation. If we cannot exit the
             # simulation, this probably means that we are running in QEMU. So, ignore
             # future calls to gem5-bridge.
-            if ! gem5-bridge exit; then
+            if ! echo 0 > /dev/gem5/exit; then
                 # Useful for booting the disk image in (e.g.,) qemu for debugging
                 printf "gem5-bridge exit failed, dropping to shell.\n"
                 IGNORE_M5=1 /bin/bash
@@ -51,7 +51,7 @@ else
             /tmp/script
             printf "Done running script from gem5-bridge, exiting.\n"
             rm -f /tmp/script
-            gem5-bridge exit
+            echo 0 > /dev/gem5/exit
         fi
     fi
 fi

--- a/src/x86-ubuntu/files/exit.sh
+++ b/src/x86-ubuntu/files/exit.sh
@@ -3,4 +3,4 @@
 # Copyright (c) 2020 The Regents of the University of California.
 # SPDX-License-Identifier: BSD 3-Clause
 
-m5 exit
+echo 0 > /dev/gem5/exit

--- a/src/x86-ubuntu/files/exit.sh
+++ b/src/x86-ubuntu/files/exit.sh
@@ -3,4 +3,4 @@
 # Copyright (c) 2020 The Regents of the University of California.
 # SPDX-License-Identifier: BSD 3-Clause
 
-echo 0 > /dev/gem5/exit
+gem5-bridge exit

--- a/src/x86-ubuntu/files/gem5_init.sh
+++ b/src/x86-ubuntu/files/gem5_init.sh
@@ -16,9 +16,20 @@ cmdline=$(cat /proc/cmdline)
 no_systemd=false
 
 # Load gem5_bridge driver
+## Default parameters
+gem5_bridge_baseaddr=0xffff0000
+gem5_bridge_rangesize=0x10000
+## Try to read overloads from kernel arguments
+if [[ $cmdline =~ gem5_bridge_baseaddr=([[:alnum:]]+) ]]; then
+    gem5_bridge_baseaddr=${BASH_REMATCH[1]}
+fi
+if [[ $cmdline =~ gem5_bridge_rangesize=([[:alnum:]]+) ]]; then
+    gem5_bridge_rangesize=${BASH_REMATCH[1]}
+fi
+## Insert driver
 modprobe gem5_bridge \
-    gem5_bridge_baseaddr=0xffff0000 \
-    gem5_bridge_rangesize=0x10000
+    gem5_bridge_baseaddr=$gem5_bridge_baseaddr \
+    gem5_bridge_rangesize=$gem5_bridge_rangesize
 
 # gem5-bridge exit signifying that kernel is booted
 # This will cause the simulation to exit. Note that this will

--- a/src/x86-ubuntu/files/gem5_init.sh
+++ b/src/x86-ubuntu/files/gem5_init.sh
@@ -16,8 +16,7 @@ cmdline=$(cat /proc/cmdline)
 no_systemd=false
 
 # Load gem5_bridge driver
-depmod --quick
-modprobe gem5_bridge
+modprobe gem5_bridge || insmod /lib/modules/$(uname -r)/gem5/gem5_bridge.ko
 
 # gem5-bridge exit signifying that kernel is booted
 # This will cause the simulation to exit. Note that this will

--- a/src/x86-ubuntu/files/gem5_init.sh
+++ b/src/x86-ubuntu/files/gem5_init.sh
@@ -35,7 +35,7 @@ modprobe gem5_bridge \
 # This will cause the simulation to exit. Note that this will
 # cause qemu to fail.
 printf "Kernel booted, In gem5 init...\n"
-echo 0 > /dev/gem5/exit # TODO: Make this a specialized event.
+gem5-bridge exit # TODO: Make this a specialized event.
 
 if [[ $cmdline == *"no_systemd"* ]]; then
     no_systemd=true

--- a/src/x86-ubuntu/files/gem5_init.sh
+++ b/src/x86-ubuntu/files/gem5_init.sh
@@ -15,6 +15,10 @@ mount -t sysfs /sys /sys
 cmdline=$(cat /proc/cmdline)
 no_systemd=false
 
+# Load gem5_bridge driver
+depmod --quick
+modprobe gem5_bridge
+
 # gem5-bridge exit signifying that kernel is booted
 # This will cause the simulation to exit. Note that this will
 # cause qemu to fail.

--- a/src/x86-ubuntu/files/gem5_init.sh
+++ b/src/x86-ubuntu/files/gem5_init.sh
@@ -16,7 +16,7 @@ cmdline=$(cat /proc/cmdline)
 no_systemd=false
 
 # Load gem5_bridge driver
-## Default parameters
+## Default parameters (x86_64)
 gem5_bridge_baseaddr=0xffff0000
 gem5_bridge_rangesize=0x10000
 ## Try to read overloads from kernel arguments

--- a/src/x86-ubuntu/files/gem5_init.sh
+++ b/src/x86-ubuntu/files/gem5_init.sh
@@ -22,7 +22,7 @@ modprobe gem5_bridge || insmod /lib/modules/$(uname -r)/gem5/gem5_bridge.ko
 # This will cause the simulation to exit. Note that this will
 # cause qemu to fail.
 printf "Kernel booted, In gem5 init...\n"
-gem5-bridge exit # TODO: Make this a specialized event.
+echo 0 > /dev/gem5/exit # TODO: Make this a specialized event.
 
 if [[ $cmdline == *"no_systemd"* ]]; then
     no_systemd=true

--- a/src/x86-ubuntu/files/gem5_init.sh
+++ b/src/x86-ubuntu/files/gem5_init.sh
@@ -16,7 +16,9 @@ cmdline=$(cat /proc/cmdline)
 no_systemd=false
 
 # Load gem5_bridge driver
-modprobe gem5_bridge || insmod /lib/modules/$(uname -r)/gem5/gem5_bridge.ko
+modprobe gem5_bridge \
+    gem5_bridge_baseaddr=0xffff0000 \
+    gem5_bridge_rangesize=0x10000
 
 # gem5-bridge exit signifying that kernel is booted
 # This will cause the simulation to exit. Note that this will

--- a/src/x86-ubuntu/scripts/post-installation.sh
+++ b/src/x86-ubuntu/scripts/post-installation.sh
@@ -45,6 +45,7 @@ git clone https://github.com/gem5/gem5.git --depth=1 --filter=blob:none --no-che
 pushd gem5
 # Checkout just the files we need
 git sparse-checkout add util/m5
+git sparse-checkout add util/gem5_bridge
 git sparse-checkout add include
 git checkout
 # Install the headers globally so that other benchmarks can use them
@@ -55,6 +56,11 @@ pushd util/m5
 scons build/x86/out/m5
 cp build/x86/out/m5 /usr/local/bin/
 cp build/x86/out/libm5.a /usr/local/lib/
+popd
+
+# Build and insert the gem5_bridge driver
+pushd util/gem5_bridge
+make build install
 popd
 popd
 

--- a/src/x86-ubuntu/scripts/post-installation.sh
+++ b/src/x86-ubuntu/scripts/post-installation.sh
@@ -75,7 +75,7 @@ chmod u+s /usr/local/bin/gem5-bridge
 ln -s /usr/local/bin/gem5-bridge /usr/local/bin/m5
 
 # delete the git repo for gem5
-rm -rf gem5
+# rm -rf gem5
 echo "Done building and installing gem5-bridge (m5) and libm5"
 
 # You can extend this script to install your own packages here or by modifying the `x86-ubuntu.pkr.hcl` file.
@@ -83,14 +83,14 @@ echo "Done building and installing gem5-bridge (m5) and libm5"
 # Disable network by default
 echo "Disabling network by default"
 echo "See README.md for instructions on how to enable network"
-if [ -f /etc/netplan/50-cloud-init.yaml ]; then
-    mv /etc/netplan/50-cloud-init.yaml /etc/netplan/50-cloud-init.yaml.bak
-elif [ -f /etc/netplan/00-installer-config.yaml ]; then
-    mv /etc/netplan/00-installer-config.yaml /etc/netplan/00-installer-config.yaml.bak
-    netplan apply
-fi
+# if [ -f /etc/netplan/50-cloud-init.yaml ]; then
+#     mv /etc/netplan/50-cloud-init.yaml /etc/netplan/50-cloud-init.yaml.bak
+# elif [ -f /etc/netplan/00-installer-config.yaml ]; then
+#     mv /etc/netplan/00-installer-config.yaml /etc/netplan/00-installer-config.yaml.bak
+#     netplan apply
+# fi
 # Disable systemd service that waits for network to be online
-systemctl disable systemd-networkd-wait-online.service
-systemctl mask systemd-networkd-wait-online.service
+# systemctl disable systemd-networkd-wait-online.service
+# systemctl mask systemd-networkd-wait-online.service
 
 echo "Post Installation Done"

--- a/src/x86-ubuntu/scripts/post-installation.sh
+++ b/src/x86-ubuntu/scripts/post-installation.sh
@@ -58,9 +58,10 @@ cp build/x86/out/m5 /usr/local/bin/
 cp build/x86/out/libm5.a /usr/local/lib/
 popd
 
-# Build and insert the gem5_bridge driver
+# Build and insert the gem5-bridge driver
 pushd util/gem5_bridge
 make build install
+depmod --quick
 popd
 popd
 

--- a/src/x86-ubuntu/scripts/post-installation.sh
+++ b/src/x86-ubuntu/scripts/post-installation.sh
@@ -41,7 +41,7 @@ rm /etc/update-motd.d/*
 echo "Building and installing gem5-bridge (m5) and libm5"
 
 # Just get the files we need
-git clone https://github.com/gem5/gem5.git --depth=1 --filter=blob:none --no-checkout --sparse --single-branch --branch=stable
+git clone https://github.com/nkrim/gem5.git --depth=1 --filter=blob:none --no-checkout --sparse --single-branch --branch=gem5-bridge
 pushd gem5
 # Checkout just the files we need
 git sparse-checkout add util/m5

--- a/src/x86-ubuntu/x86-ubuntu.pkr.hcl
+++ b/src/x86-ubuntu/x86-ubuntu.pkr.hcl
@@ -78,8 +78,8 @@ build {
   }
 
   provisioner "file" {
-  source      = "/home/gem5/vmlinux-x86-ubuntu"
-  destination = "./disk-image/vmlinux-x86-ubuntu"
-  direction   = "download"
+    source      = "/home/gem5/vmlinux-x86-ubuntu"
+    destination = "./disk-image/vmlinux-x86-ubuntu"
+    direction   = "download"
   }
 }


### PR DESCRIPTION
Adds commands to `scripts/post-installation.sh` to make the driver during disk building. The Makefile can take arguments to modify the base address for the gem5ops MMIO range by putting `GEM5OPS_BASE=<base_phys_addr>` at the end of the make command.

Adds commands to `files/gem5_init.sh` to detect and add the driver after kernel startup but just before the first `gem5-bridge exit`.

Relates to https://github.com/gem5/gem5/pull/1480