### PR TITLE
resources: Add script that allows to extend a base image

### DIFF
--- a/src/base-img update/build.sh
+++ b/src/base-img update/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright (c) 2024 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+PACKER_VERSION="1.10.0"
+
+if [ ! -f ./packer ]; then
+    wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip;
+    unzip packer_${PACKER_VERSION}_linux_amd64.zip;
+    rm packer_${PACKER_VERSION}_linux_amd64.zip;
+fi
+
+
+# Ensure the script is run with two arguments
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <path_to_base_image> <output_directory>"
+    exit 1
+fi
+
+# Assign arguments to variables
+BASE_IMAGE_PATH=$1
+OUTPUT_DIRECTORY=$2
+
+# Calculate the sha256 checksum of the base image
+ISO_CHECKSUM=$(sha256sum "$BASE_IMAGE_PATH" | awk '{ print $1 }')
+
+
+# Install the needed plugins
+./packer init x86-base-image-udpate.pkr.hcl
+
+# Run the packer build command with the variables
+packer build -var "base_image_path=$BASE_IMAGE_PATH" -var "output_directory=$OUTPUT_DIRECTORY" -var "iso_checksum=$ISO_CHECKSUM" x86-base-image-udpate.pkr.hcl

--- a/src/base-img update/scripts/post-installation.sh
+++ b/src/base-img update/scripts/post-installation.sh
@@ -1,0 +1,1 @@
+# add commands to install your packages here

--- a/src/base-img update/x86-base-image-udpate.pkr.hcl
+++ b/src/base-img update/x86-base-image-udpate.pkr.hcl
@@ -1,0 +1,71 @@
+packer {
+  required_plugins {
+    qemu = {
+      source  = "github.com/hashicorp/qemu"
+      version = "~> 1"
+    }
+  }
+}
+
+variable "image_name" {
+  type    = string
+  default = "x86-ubuntu-24-04" # default name can be updated
+}
+
+variable "ssh_password" {
+  type    = string
+  default = "12345" # Update ssh_password if it different for the base image
+}
+
+variable "ssh_username" {
+  type    = string
+  default = "gem5" # Update user if it is different for the base image
+}
+
+variable "output_directory" {
+  type    = string
+  default = "disk-image-ubuntu-24-04"  # Default directory, can be overridden by script
+}
+
+variable "base_image_path" {
+  type    = string
+}
+
+variable "iso_checksum" {
+  type    = string
+}
+
+source "qemu" "initialize" {
+  accelerator      = "kvm"
+  boot_command     = [] # If you want packer to type any commands or anything else to the terminal after booting, edit this parameter
+  cpus             = "4"
+  disk_size        = "5000"
+  format           = "raw"
+  headless         = "true"
+  disk_image       = "true"
+  iso_checksum     = "sha256:${var.iso_checksum}"
+  iso_urls         = ["${var.base_image_path}"]
+  memory           = "8192"
+  output_directory = "${var.output_directory}"
+  qemu_binary      = "/usr/bin/qemu-system-x86_64"
+  qemuargs         = [["-cpu", "host"], ["-display", "none"]]
+  shutdown_command = "echo '${var.ssh_password}'|sudo -S shutdown -P now"
+  ssh_password     = "${var.ssh_password}"
+  ssh_username     = "${var.ssh_username}"
+  ssh_wait_timeout = "60m"
+  vm_name          = "${var.image_name}"
+  ssh_handshake_attempts = "1000"
+}
+
+build {
+  sources = ["source.qemu.initialize"]
+
+  provisioner "shell" {
+    execute_command = "echo '${var.ssh_password}' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'"
+    scripts         = ["scripts/post-installation.sh"] # this script is blank, add anything you want to run on the image after image is booted
+    expect_disconnect = true
+  }
+
+
+
+}


### PR DESCRIPTION
- Added a minimal template packer script that allows users to extend a base image

- Added a build.sh script which takes in base image path and output directory as arguments to build the new image

- Added comments in the packer file that explain what to change to make further modifications such as ssh name, ssh password, boot command, etc.