### PR TITLE
resources: add Arm SPEC 2006 Ubuntu 24.04 disk image

### DIFF
--- a/src/arm-ubuntu-spec-2006/README.md
+++ b/src/arm-ubuntu-spec-2006/README.md
@@ -1,0 +1,201 @@
+---
+title: Linux arm-ubuntu image
+tags:
+    - arm
+    - fullsystem
+layout: default
+permalink: resources/arm-ubuntu
+shortdoc: >
+    Resources to build a generic arm-ubuntu disk image.
+author: ["Hoa Nguyen", "Kaustav Goswami"]
+---
+
+This document provides instructions to create the "arm-ubuntu" image and
+points to the gem5 component that would work with the disk image. The
+arm-ubuntu disk image is based on Ubuntu's server cloud image for
+arm available at (https://cloud-images.ubuntu.com/focal/current/).
+The `.bashrc` file would be modified in such a way that it executes
+a script passed from the gem5 configuration files (using the `m5 readfile`
+instruction).
+
+The instructions for bringing up QEMU emulation are based on
+[Ubuntu's Wiki](https://wiki.ubuntu.com/ARM64/QEMU),
+and the instructions for creating a cloud disk image are based on
+[this guide](https://gist.github.com/oznu/ac9efae7c24fd1f37f1d933254587aa4).
+More information about cloud-init can be found
+[here](https://cloudinit.readthedocs.io/en/latest/topics/examples.html).
+
+We assume the following directory structure while following the instructions
+in this README file:
+
+```
+arm-ubuntu/
+  |___ gem5/                                   # gem5 source code (to be cloned here)
+  |
+  |___ disk-image/
+  |      |___ aarch64-ubuntu.img               # The ubuntu disk image should be downloaded and modified here
+  |      |___ shared/                          # Auxiliary files needed for disk creation
+  |      |      |___ serial-getty@.service     # Auto-login script
+  |      |___ arm-ubuntu/
+  |             |___ cloud.txt                 # the cloud config, to be created
+  |             |___ gem5_init.sh              # The script to be appended to .bashrc on the disk image
+  |             |___ post-installation.sh      # The script manipulating the disk image
+  |             |___ arm-ubuntu.json           # The Packer script
+  |
+  |
+  |___ README.md                               # This README file
+```
+
+## Building the disk image
+
+This requires an ARM cross compiler to be installed. The disk image is a 64-bit
+ARM 64 (aarch64) disk image. Therefore, we only focus on the 64-bit version of
+the cross compiler. It can be installed by:
+
+```sh
+sudo apt-get install g++-10-aarch64-linux-gnu gcc-10-aarch64-linux-gnu
+```
+
+In order to build the ARM based Ubuntu disk-image for with gem5, build the m5
+utility in `gem5/util/m5` using the following:
+
+```sh
+git clone https://gem5.googlesource.com/public/gem5
+cd gem5/util/m5
+scons build/arm64/out/m5
+```
+
+Troubleshooting: You may need to edit the SConscript to point to the correct
+cross compiler.
+```
+...
+main['CXX'] = '${CROSS_COMPILE}g++-10'
+...
+```
+
+# Installing QEMU for aarch64
+
+On the host machine,
+
+```sh
+sudo apt-get install qemu-system-arm qemu-efi
+```
+
+# Installing cloud utilities
+
+On the host machine,
+
+```sh
+sudo apt-get install cloud-utils
+```
+
+# Downloading the cloud disk image
+
+In the `arm-ubuntu/disk-image/` directory,
+
+```sh
+wget https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img
+```
+
+# Booting the disk image using QEMU
+
+## Generating an SSH key pair
+```sh
+ssh-keygen -t rsa -b 4096
+```
+Leave all prompted fields empty and hit enter. This will generate a public and
+private key pair in files `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`. If your username
+is different from what is printed by command `whoami`, then add `-C "<username>*<hostname>"`
+to the command:
+```sh
+ssh-keygen -t rsa -b 4096 -C "<username>*<hostname>"
+```
+
+## Making a cloud config file
+
+First, we need a cloud config that will have the authorization information
+keys for logging in the machine.
+
+In the `arm-ubuntu/disk-image/arm-ubuntu` directory, create a `cloud.txt` file
+with the following content,
+
+```sh
+#cloud-config
+users:
+  - name: ubuntu                            <- change this name to the current user (use `whoami`)
+    ssh-authorized-keys:
+      - ssh-rsa AAAAABBCCCCCCCrNJfweeeeee   <- insert the rsa key here (typically `cat ~/.ssh/id_rsa.pub`)
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    groups: sudo
+    shell: /bin/bash
+    homedir: /home/ubuntu                   <- change this to the home directory of `whoami`
+```
+
+* Note: Do not leave stray spaces in the `cloud.txt` file.
+* If your username is different from what is printed by command `whoami`, then use that for parameter "name" in cloud.txt
+
+More information about generating an ssh rsa key is available
+[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key).
+You can ignore the GitHub email address part.
+
+## Booting the cloud disk image with the cloud config file
+In the `arm-ubuntu/disk-image` directory,
+
+```sh
+dd if=/dev/zero of=flash0.img bs=1M count=64
+dd if=/usr/share/qemu-efi/QEMU_EFI.fd of=flash0.img conv=notrunc
+dd if=/dev/zero of=flash1.img bs=1M count=64
+cloud-localds --disk-format qcow2 cloud.img arm-ubuntu/cloud.txt
+wget https://releases.linaro.org/components/kernel/uefi-linaro/latest/release/qemu64/QEMU_EFI.fd
+qemu-system-aarch64 \
+    -smp 2 \
+    -m 1024 \
+    -M virt \
+    -cpu cortex-a57 \
+    -bios QEMU_EFI.fd \
+    -nographic \
+    -device virtio-blk-device,drive=image \
+    -drive if=none,id=image,file=focal-server-cloudimg-arm64.img \
+    -device virtio-blk-device,drive=cloud \
+    -drive if=none,id=cloud,file=cloud.img \
+    -netdev user,id=user0 -device virtio-net-device,netdev=eth0 \
+    -netdev user,id=eth0,hostfwd=tcp::5555-:22
+```
+
+## Manipulating the disk image
+
+When the qemu instance has fully booted, cloud-init has completed, and while it
+is still running, we will use Packer to connect to the virtual machine and
+manipulate the disk image. Before doing that, we need to add the private key using `ssh-add`.
+
+```sh
+ssh-add ~/.ssh/id_rsa
+```
+
+If the image was booted in qemu on a port number other than 5555, edit the `ssh_port`
+parameter in `arm-ubuntu/arm-ubuntu.json` accordingly. The disk manipulation
+process is automated. If your username is different from what is printed by
+command `whoami`, then edit `build.sh` and change the value of `USER` to `"<your_username>"`.
+Then in the `arm-ubuntu/disk-image/` directory,
+
+```sh
+chmod +x build.sh
+./build.sh
+```
+
+`build.sh` also verifies the cloud.txt and modifies the arm-ubuntu.json
+accordingly. The packer script, executed by `build.sh` disables systemd. In
+case you need to enable systemd stuff, remove the last two provisioners from
+the arm-ubuntu.json file.
+
+Note that after executing the packer script, you will not be able to emulate
+this disk image in qemu.
+
+## Preparing the disk image for gem5
+
+We need to finalize the image before we can use it with gem5. This is done by:
+
+```sh
+qemu-img convert -f qcow2 -O raw focal-server-cloudimg-arm64.img arm64-ubuntu-focal-server.img
+rm focal-server-cloudimg-arm64.img
+```

--- a/src/arm-ubuntu-spec-2006/arm-ubuntu-24-04.pkr.hcl
+++ b/src/arm-ubuntu-spec-2006/arm-ubuntu-24-04.pkr.hcl
@@ -1,0 +1,127 @@
+packer {
+  required_plugins {
+    qemu = {
+      source  = "github.com/hashicorp/qemu"
+      version = "~> 1"
+    }
+  }
+}
+
+variable "image_name" {
+  type    = string
+  default = "arm-ubuntu"
+}
+
+variable "ssh_password" {
+  type    = string
+  default = "12345"
+}
+
+variable "ssh_username" {
+  type    = string
+  default = "gem5"
+}
+
+source "qemu" "initialize" {
+  boot_command     = [
+                      "c<wait>",
+                      "linux /casper/vmlinuz autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ --- ",
+                      "<enter><wait>",
+                      "initrd /casper/initrd",
+                      "<enter><wait>",
+                      "boot",
+                      "<enter>",
+                      "<wait>"
+                      ]
+  cpus             = "4"
+  disk_size        = "18400"
+  format           = "raw"
+  headless         = "true"
+  http_directory   = "http-24-04"
+  iso_checksum     = "sha256:d2d9986ada3864666e36a57634dfc97d17ad921fa44c56eeaca801e7dab08ad7"
+  iso_urls         = ["https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-arm64.iso"]
+  memory           = "8192"
+  output_directory = "disk-image-24-04"
+  qemu_binary      = "/usr/bin/qemu-system-aarch64"
+  qemuargs         = [  ["-boot", "order=dc"],
+                        ["-bios", "./files/flash0.img"],
+                        ["-cpu", "host"],
+                        ["-enable-kvm"],
+                        ["-machine", "virt"],
+                        ["-machine", "gic-version=3"],
+                        ["-vga", "virtio"],
+                        ["-device","virtio-gpu-pci"],
+                        ["-device", "qemu-xhci"],
+                        ["-device","usb-kbd"],
+
+                      ]
+  shutdown_command = "echo '${var.ssh_password}'|sudo -S shutdown -P now"
+  ssh_password     = "${var.ssh_password}"
+  ssh_username     = "${var.ssh_username}"
+  ssh_wait_timeout = "60m"
+  vm_name          = "${var.image_name}"
+  ssh_handshake_attempts = "1000"
+}
+
+
+build {
+  sources = ["source.qemu.initialize"]
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/exit.sh"
+  }
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/gem5_init.sh"
+  }
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/after_boot.sh"
+  }
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "/home/bees/gem5-bootcamp-private/CPU2006v1.0.1.iso"
+  }
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/serial-getty@.service"
+  }
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/glob.c"
+  }
+
+    provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/makedepend.SH"
+  }
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/md5sum.c"
+  }
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/SysV.xs"
+  }
+
+  provisioner "file" {
+    destination = "/home/gem5/"
+    source      = "files/replace-configs.sh"
+  }
+
+
+  provisioner "shell" {
+    execute_command = "echo '${var.ssh_password}' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'"
+    scripts         = ["scripts/post-installation.sh", "scripts/install-spec2006.sh"]
+    expect_disconnect = true
+  }
+
+}

--- a/src/arm-ubuntu-spec-2006/build.sh
+++ b/src/arm-ubuntu-spec-2006/build.sh
@@ -1,0 +1,27 @@
+PACKER_VERSION="1.10.0"
+
+if [ ! -f ./packer ]; then
+    wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_arm64.zip;
+    unzip packer_${PACKER_VERSION}_linux_arm64.zip;
+    rm packer_${PACKER_VERSION}_linux_arm64.zip;
+fi
+
+# Check if the configuration file variable is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <configuration_file>"
+    exit 1
+fi
+
+# Store the configuration file name from the command line argument
+config_file="$1"
+
+# Check if the specified configuration file exists
+if [ -f "$config_file" ]; then
+    # Install the needed plugins
+    PACKER_LOG=1 ./packer init "$config_file"
+    # Build the image
+    PACKER_LOG=1 ./packer build "$config_file"
+else
+    echo "Error: Configuration file '$config_file' not found."
+    exit 1
+fi

--- a/src/arm-ubuntu-spec-2006/files/SysV.xs
+++ b/src/arm-ubuntu-spec-2006/files/SysV.xs
@@ -1,0 +1,442 @@
+#include "EXTERN.h"
+#include "perl.h"
+#include "XSUB.h"
+
+#include <sys/types.h>
+#ifdef __linux__
+// #   include <asm/page.h>
+#endif
+#if defined(HAS_MSG) || defined(HAS_SEM) || defined(HAS_SHM)
+#ifndef HAS_SEM
+#   include <sys/ipc.h>
+#endif
+#   ifdef HAS_MSG
+#       include <sys/msg.h>
+#   endif
+#   ifdef HAS_SHM
+#       if defined(PERL_SCO) || defined(PERL_ISC)
+#           include <sys/sysmacros.h>	/* SHMLBA */
+#       endif
+#      include <sys/shm.h>
+#      ifndef HAS_SHMAT_PROTOTYPE
+           extern Shmat_t shmat (int, char *, int);
+#      endif
+#      if defined(__sparc__) && (defined(__NetBSD__) || defined(__OpenBSD__))
+#          undef  SHMLBA /* not static: determined at boot time */
+#          define SHMLBA getpagesize()
+#      endif
+#   endif
+#endif
+
+/* Required to get 'struct pte' for SHMLBA on ULTRIX. */
+#if defined(__ultrix) || defined(__ultrix__) || defined(ultrix)
+#include <machine/pte.h>
+#endif
+
+/* Required in BSDI to get PAGE_SIZE definition for SHMLBA.
+ * Ugly.  More beautiful solutions welcome.
+ * Shouting at BSDI sounds quite beautiful. */
+#ifdef __bsdi__
+#   include <vm/vm_param.h>	/* move upwards under HAS_SHM? */
+#endif
+
+#ifndef S_IRWXU
+#   ifdef S_IRUSR
+#       define S_IRWXU (S_IRUSR|S_IWUSR|S_IWUSR)
+#       define S_IRWXG (S_IRGRP|S_IWGRP|S_IWGRP)
+#       define S_IRWXO (S_IROTH|S_IWOTH|S_IWOTH)
+#   else
+#       define S_IRWXU 0700
+#       define S_IRWXG 0070
+#       define S_IRWXO 0007
+#   endif
+#endif
+
+MODULE=IPC::SysV	PACKAGE=IPC::Msg::stat
+
+PROTOTYPES: ENABLE
+
+void
+pack(obj)
+    SV	* obj
+PPCODE:
+{
+#ifdef HAS_MSG
+    SV *sv;
+    struct msqid_ds ds;
+    AV *list = (AV*)SvRV(obj);
+    sv = *av_fetch(list,0,TRUE); ds.msg_perm.uid = SvIV(sv);
+    sv = *av_fetch(list,1,TRUE); ds.msg_perm.gid = SvIV(sv);
+    sv = *av_fetch(list,4,TRUE); ds.msg_perm.mode = SvIV(sv);
+    sv = *av_fetch(list,6,TRUE); ds.msg_qbytes = SvIV(sv);
+    ST(0) = sv_2mortal(newSVpvn((char *)&ds,sizeof(ds)));
+    XSRETURN(1);
+#else
+    croak("System V msgxxx is not implemented on this machine");
+#endif
+}
+
+void
+unpack(obj,buf)
+    SV * obj
+    SV * buf
+PPCODE:
+{
+#ifdef HAS_MSG
+    STRLEN len;
+    SV **sv_ptr;
+    struct msqid_ds *ds = (struct msqid_ds *)SvPV(buf,len);
+    AV *list = (AV*)SvRV(obj);
+    if (len != sizeof(*ds)) {
+	croak("Bad arg length for %s, length is %d, should be %d",
+		    "IPC::Msg::stat",
+		    len, sizeof(*ds));
+    }
+    sv_ptr = av_fetch(list,0,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_perm.uid);
+    sv_ptr = av_fetch(list,1,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_perm.gid);
+    sv_ptr = av_fetch(list,2,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_perm.cuid);
+    sv_ptr = av_fetch(list,3,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_perm.cgid);
+    sv_ptr = av_fetch(list,4,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_perm.mode);
+    sv_ptr = av_fetch(list,5,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_qnum);
+    sv_ptr = av_fetch(list,6,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_qbytes);
+    sv_ptr = av_fetch(list,7,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_lspid);
+    sv_ptr = av_fetch(list,8,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_lrpid);
+    sv_ptr = av_fetch(list,9,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_stime);
+    sv_ptr = av_fetch(list,10,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_rtime);
+    sv_ptr = av_fetch(list,11,TRUE);
+    sv_setiv(*sv_ptr, ds->msg_ctime);
+    XSRETURN(1);
+#else
+    croak("System V msgxxx is not implemented on this machine");
+#endif
+}
+
+MODULE=IPC::SysV	PACKAGE=IPC::Semaphore::stat
+
+void
+unpack(obj,ds)
+    SV * obj
+    SV * ds
+PPCODE:
+{
+#ifdef HAS_SEM
+    STRLEN len;
+    AV *list = (AV*)SvRV(obj);
+    struct semid_ds *data = (struct semid_ds *)SvPV(ds,len);
+    if(!sv_isa(obj, "IPC::Semaphore::stat"))
+	croak("method %s not called a %s object",
+		"unpack","IPC::Semaphore::stat");
+    if (len != sizeof(*data)) {
+	croak("Bad arg length for %s, length is %d, should be %d",
+		    "IPC::Semaphore::stat",
+		    len, sizeof(*data));
+    }
+    sv_setiv(*av_fetch(list,0,TRUE), data[0].sem_perm.uid);
+    sv_setiv(*av_fetch(list,1,TRUE), data[0].sem_perm.gid);
+    sv_setiv(*av_fetch(list,2,TRUE), data[0].sem_perm.cuid);
+    sv_setiv(*av_fetch(list,3,TRUE), data[0].sem_perm.cgid);
+    sv_setiv(*av_fetch(list,4,TRUE), data[0].sem_perm.mode);
+    sv_setiv(*av_fetch(list,5,TRUE), data[0].sem_ctime);
+    sv_setiv(*av_fetch(list,6,TRUE), data[0].sem_otime);
+    sv_setiv(*av_fetch(list,7,TRUE), data[0].sem_nsems);
+    XSRETURN(1);
+#else
+    croak("System V semxxx is not implemented on this machine");
+#endif
+}
+
+void
+pack(obj)
+    SV	* obj
+PPCODE:
+{
+#ifdef HAS_SEM
+    SV **sv_ptr;
+    struct semid_ds ds;
+    AV *list = (AV*)SvRV(obj);
+    if(!sv_isa(obj, "IPC::Semaphore::stat"))
+	croak("method %s not called a %s object",
+		"pack","IPC::Semaphore::stat");
+    if((sv_ptr = av_fetch(list,0,TRUE)) && *sv_ptr)
+	ds.sem_perm.uid = SvIV(*sv_ptr);
+    if((sv_ptr = av_fetch(list,1,TRUE)) && *sv_ptr)
+	ds.sem_perm.gid = SvIV(*sv_ptr);
+    if((sv_ptr = av_fetch(list,2,TRUE)) && *sv_ptr)
+	ds.sem_perm.cuid = SvIV(*sv_ptr);
+    if((sv_ptr = av_fetch(list,3,TRUE)) && *sv_ptr)
+	ds.sem_perm.cgid = SvIV(*sv_ptr);
+    if((sv_ptr = av_fetch(list,4,TRUE)) && *sv_ptr)
+	ds.sem_perm.mode = SvIV(*sv_ptr);
+    if((sv_ptr = av_fetch(list,5,TRUE)) && *sv_ptr)
+	ds.sem_ctime = SvIV(*sv_ptr);
+    if((sv_ptr = av_fetch(list,6,TRUE)) && *sv_ptr)
+	ds.sem_otime = SvIV(*sv_ptr);
+    if((sv_ptr = av_fetch(list,7,TRUE)) && *sv_ptr)
+	ds.sem_nsems = SvIV(*sv_ptr);
+    ST(0) = sv_2mortal(newSVpvn((char *)&ds,sizeof(ds)));
+    XSRETURN(1);
+#else
+    croak("System V semxxx is not implemented on this machine");
+#endif
+}
+
+MODULE=IPC::SysV	PACKAGE=IPC::SysV
+
+void
+ftok(path, id)
+        char *          path
+        int             id
+    CODE:
+#if defined(HAS_SEM) || defined(HAS_SHM)
+        key_t k = ftok(path, id);
+        ST(0) = k == (key_t) -1 ? &PL_sv_undef : sv_2mortal(newSViv(k));
+#else
+	Perl_die(aTHX_ PL_no_func, "ftok"); return;
+#endif
+
+void
+SHMLBA()
+    CODE:
+#ifdef SHMLBA
+    ST(0) = sv_2mortal(newSViv(SHMLBA));
+#else
+    croak("SHMLBA is not defined on this architecture");
+#endif
+
+BOOT:
+{
+    HV *stash = gv_stashpvn("IPC::SysV", 9, TRUE);
+    /*
+     * constant subs for IPC::SysV
+     */
+     struct { char *n; I32 v; } IPC__SysV__const[] = {
+#ifdef GETVAL
+        {"GETVAL", GETVAL},
+#endif
+#ifdef GETPID
+        {"GETPID", GETPID},
+#endif
+#ifdef GETNCNT
+        {"GETNCNT", GETNCNT},
+#endif
+#ifdef GETZCNT
+        {"GETZCNT", GETZCNT},
+#endif
+#ifdef GETALL
+        {"GETALL", GETALL},
+#endif
+#ifdef IPC_ALLOC
+        {"IPC_ALLOC", IPC_ALLOC},
+#endif
+#ifdef IPC_CREAT
+        {"IPC_CREAT", IPC_CREAT},
+#endif
+#ifdef IPC_EXCL
+        {"IPC_EXCL", IPC_EXCL},
+#endif
+#ifdef IPC_GETACL
+        {"IPC_GETACL", IPC_EXCL},
+#endif
+#ifdef IPC_LOCKED
+        {"IPC_LOCKED", IPC_LOCKED},
+#endif
+#ifdef IPC_M
+        {"IPC_M", IPC_M},
+#endif
+#ifdef IPC_NOERROR
+        {"IPC_NOERROR", IPC_NOERROR},
+#endif
+#ifdef IPC_NOWAIT
+        {"IPC_NOWAIT", IPC_NOWAIT},
+#endif
+#ifdef IPC_PRIVATE
+        {"IPC_PRIVATE", IPC_PRIVATE},
+#endif
+#ifdef IPC_R
+        {"IPC_R", IPC_R},
+#endif
+#ifdef IPC_RMID
+        {"IPC_RMID", IPC_RMID},
+#endif
+#ifdef IPC_SET
+        {"IPC_SET", IPC_SET},
+#endif
+#ifdef IPC_SETACL
+        {"IPC_SETACL", IPC_SETACL},
+#endif
+#ifdef IPC_SETLABEL
+        {"IPC_SETLABEL", IPC_SETLABEL},
+#endif
+#ifdef IPC_STAT
+        {"IPC_STAT", IPC_STAT},
+#endif
+#ifdef IPC_W
+        {"IPC_W", IPC_W},
+#endif
+#ifdef IPC_WANTED
+        {"IPC_WANTED", IPC_WANTED},
+#endif
+#ifdef MSG_NOERROR
+        {"MSG_NOERROR", MSG_NOERROR},
+#endif
+#ifdef MSG_FWAIT
+        {"MSG_FWAIT", MSG_FWAIT},
+#endif
+#ifdef MSG_LOCKED
+        {"MSG_LOCKED", MSG_LOCKED},
+#endif
+#ifdef MSG_MWAIT
+        {"MSG_MWAIT", MSG_MWAIT},
+#endif
+#ifdef MSG_WAIT
+        {"MSG_WAIT", MSG_WAIT},
+#endif
+#ifdef MSG_R
+        {"MSG_R", MSG_R},
+#endif
+#ifdef MSG_RWAIT
+        {"MSG_RWAIT", MSG_RWAIT},
+#endif
+#ifdef MSG_STAT
+        {"MSG_STAT", MSG_STAT},
+#endif
+#ifdef MSG_W
+        {"MSG_W", MSG_W},
+#endif
+#ifdef MSG_WWAIT
+        {"MSG_WWAIT", MSG_WWAIT},
+#endif
+#ifdef SEM_A
+        {"SEM_A", SEM_A},
+#endif
+#ifdef SEM_ALLOC
+        {"SEM_ALLOC", SEM_ALLOC},
+#endif
+#ifdef SEM_DEST
+        {"SEM_DEST", SEM_DEST},
+#endif
+#ifdef SEM_ERR
+        {"SEM_ERR", SEM_ERR},
+#endif
+#ifdef SEM_R
+        {"SEM_R", SEM_R},
+#endif
+#ifdef SEM_ORDER
+        {"SEM_ORDER", SEM_ORDER},
+#endif
+#ifdef SEM_UNDO
+        {"SEM_UNDO", SEM_UNDO},
+#endif
+#ifdef SETVAL
+        {"SETVAL", SETVAL},
+#endif
+#ifdef SETALL
+        {"SETALL", SETALL},
+#endif
+#ifdef SHM_CLEAR
+        {"SHM_CLEAR", SHM_CLEAR},
+#endif
+#ifdef SHM_COPY
+        {"SHM_COPY", SHM_COPY},
+#endif
+#ifdef SHM_DCACHE
+        {"SHM_DCACHE", SHM_DCACHE},
+#endif
+#ifdef SHM_DEST
+        {"SHM_DEST", SHM_DEST},
+#endif
+#ifdef SHM_ECACHE
+        {"SHM_ECACHE", SHM_ECACHE},
+#endif
+#ifdef SHM_FMAP
+        {"SHM_FMAP", SHM_FMAP},
+#endif
+#ifdef SHM_ICACHE
+        {"SHM_ICACHE", SHM_ICACHE},
+#endif
+#ifdef SHM_INIT
+        {"SHM_INIT", SHM_INIT},
+#endif
+#ifdef SHM_LOCK
+        {"SHM_LOCK", SHM_LOCK},
+#endif
+#ifdef SHM_LOCKED
+        {"SHM_LOCKED", SHM_LOCKED},
+#endif
+#ifdef SHM_MAP
+        {"SHM_MAP", SHM_MAP},
+#endif
+#ifdef SHM_NOSWAP
+        {"SHM_NOSWAP", SHM_NOSWAP},
+#endif
+#ifdef SHM_RDONLY
+        {"SHM_RDONLY", SHM_RDONLY},
+#endif
+#ifdef SHM_REMOVED
+        {"SHM_REMOVED", SHM_REMOVED},
+#endif
+#ifdef SHM_RND
+        {"SHM_RND", SHM_RND},
+#endif
+#ifdef SHM_SHARE_MMU
+        {"SHM_SHARE_MMU", SHM_SHARE_MMU},
+#endif
+#ifdef SHM_SHATTR
+        {"SHM_SHATTR", SHM_SHATTR},
+#endif
+#ifdef SHM_SIZE
+        {"SHM_SIZE", SHM_SIZE},
+#endif
+#ifdef SHM_UNLOCK
+        {"SHM_UNLOCK", SHM_UNLOCK},
+#endif
+#ifdef SHM_W
+        {"SHM_W", SHM_W},
+#endif
+#ifdef S_IRUSR
+        {"S_IRUSR", S_IRUSR},
+#endif
+#ifdef S_IWUSR
+        {"S_IWUSR", S_IWUSR},
+#endif
+#ifdef S_IRWXU
+        {"S_IRWXU", S_IRWXU},
+#endif
+#ifdef S_IRGRP
+        {"S_IRGRP", S_IRGRP},
+#endif
+#ifdef S_IWGRP
+        {"S_IWGRP", S_IWGRP},
+#endif
+#ifdef S_IRWXG
+        {"S_IRWXG", S_IRWXG},
+#endif
+#ifdef S_IROTH
+        {"S_IROTH", S_IROTH},
+#endif
+#ifdef S_IWOTH
+        {"S_IWOTH", S_IWOTH},
+#endif
+#ifdef S_IRWXO
+        {"S_IRWXO", S_IRWXO},
+#endif
+	{Nullch,0}};
+    char *name;
+    int i;
+
+    for(i = 0 ; (name = IPC__SysV__const[i].n) ; i++) {
+	newCONSTSUB(stash,name, newSViv(IPC__SysV__const[i].v));
+    }
+}
+

--- a/src/arm-ubuntu-spec-2006/files/after_boot.sh
+++ b/src/arm-ubuntu-spec-2006/files/after_boot.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright (c) 2022,2024 The University of California.
+# Copyright (c) 2021 The University of Texas at Austin.
+# SPDX-License-Identifier: BSD 3-Clause
+
+# This file is executed at the end of the bashrc for the gem5 user.
+# The script checks to see if we should run in interactive mode or not.
+# If we are in interactive mode, the script will drop to a shell.
+# If we are not in interactive mode, the script will check if we should
+# run a script from the gem5-bridge. If so, it will run the script and
+# exit. If there is no script and we are not in interactive mode, it will
+# exit. This last option is used for testing purposes.
+
+# gem5-bridge exit signifying that after_boot.sh is running
+printf "In after_boot.sh...\n"
+gem5-bridge exit # TODO: Make this a specialized event.
+
+# Read /proc/cmdline and parse options
+
+cmdline=$(cat /proc/cmdline)
+interactive=false
+IGNORE_M5=0
+if [[ $cmdline == *"interactive"* ]]; then
+    interactive=true
+fi
+
+printf "Interactive mode: $interactive\n"
+
+if [[ $interactive == true ]]; then
+    printf "Interactive mode enabled, dropping to shell."
+    /bin/bash
+else
+    # Try to read the file from the host when running with gem5
+    if ! [ -z $IGNORE_M5 ]; then
+        printf "Starting gem5 init... trying to read run script file via readfile.\n"
+        if ! gem5-bridge readfile > /tmp/script; then
+            printf "Failed to run gem5-bridge readfile, exiting!\n"
+            rm -f /tmp/script
+            # If we can't read the script exit the simulation. If we cannot exit the
+            # simulation, this probably means that we are running in QEMU. So, ignore
+            # future calls to gem5-bridge.
+            if ! gem5-bridge exit; then
+                # Useful for booting the disk image in (e.g.,) qemu for debugging
+                printf "gem5-bridge exit failed, dropping to shell.\n"
+                IGNORE_M5=1 /bin/bash
+            fi
+        else
+            printf "Running script from gem5-bridge stored in /tmp/script\n"
+            chmod 755 /tmp/script
+            /tmp/script
+            printf "Done running script from gem5-bridge, exiting.\n"
+            rm -f /tmp/script
+            gem5-bridge exit
+        fi
+    fi
+fi

--- a/src/arm-ubuntu-spec-2006/files/exit.sh
+++ b/src/arm-ubuntu-spec-2006/files/exit.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Copyright (c) 2020 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+m5 exit

--- a/src/arm-ubuntu-spec-2006/files/gem5_init.sh
+++ b/src/arm-ubuntu-spec-2006/files/gem5_init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# mount /proc and /sys
+mount -t proc /proc /proc
+mount -t sysfs /sys /sys
+# Read /proc/cmdline and parse options
+cmdline=$(cat /proc/cmdline)
+no_systemd=false
+
+# gem5-bridge exit signifying that kernel is booted
+printf "Kernel booted, starting gem5 init...\n"
+gem5-bridge exit
+
+if [[ $cmdline == *"no_systemd"* ]]; then
+    no_systemd=true
+fi
+
+# Run systemd via exec if not disabled
+if [[ $no_systemd == false ]]; then
+    # gem5-bridge exit signifying that systemd will be booted
+    printf "Starting systemd...\n"
+    exec /lib/systemd/systemd
+else
+    exec su - gem5
+fi

--- a/src/arm-ubuntu-spec-2006/files/glob.c
+++ b/src/arm-ubuntu-spec-2006/files/glob.c
@@ -1,0 +1,1428 @@
+/* Copyright (C) 1991,92,93,94,95,96,97,98,99 Free Software Foundation, Inc.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with this library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+   Boston, MA 02111-1307, USA.  */
+
+/* AIX requires this to be the first thing in the file.  */
+#if defined _AIX && !defined __GNUC__
+ #pragma alloca
+#endif
+
+#ifdef	HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+/* Enable GNU extensions in glob.h.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE	1
+#endif
+
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/* Outcomment the following line for production quality code.  */
+/* #define NDEBUG 1 */
+#include <assert.h>
+
+#include <stdio.h>		/* Needed on stupid SunOS for assert.  */
+
+
+/* Comment out all this code if we are using the GNU C Library, and are not
+   actually compiling the library itself.  This code is part of the GNU C
+   Library, but also included in many other GNU distributions.  Compiling
+   and linking in this code is a waste when using the GNU C library
+   (especially if it is a shared library).  Rather than having every GNU
+   program understand `configure --with-gnu-libc' and omit the object files,
+   it is simpler to just do this in the source for each such file.  */
+
+#define GLOB_INTERFACE_VERSION 1
+#if !defined _LIBC && defined __GNU_LIBRARY__ && __GNU_LIBRARY__ > 1
+# include <gnu-versions.h>
+# if _GNU_GLOB_INTERFACE_VERSION >= GLOB_INTERFACE_VERSION
+#  define ELIDE_CODE
+# endif
+#endif
+
+#ifndef ELIDE_CODE
+
+#if defined STDC_HEADERS || defined __GNU_LIBRARY__
+# include <stddef.h>
+#endif
+
+#if defined HAVE_UNISTD_H || defined _LIBC
+# include <unistd.h>
+# ifndef POSIX
+#  ifdef _POSIX_VERSION
+#   define POSIX
+#  endif
+# endif
+#endif
+
+#if !defined _AMIGA && !defined VMS && !defined WINDOWS32
+# include <pwd.h>
+#endif
+
+#if !defined __GNU_LIBRARY__ && !defined STDC_HEADERS
+extern int errno;
+#endif
+#ifndef __set_errno
+# define __set_errno(val) errno = (val)
+#endif
+
+#ifndef	NULL
+# define NULL	0
+#endif
+
+
+#if defined HAVE_DIRENT_H || defined __GNU_LIBRARY__
+# include <dirent.h>
+# define NAMLEN(dirent) strlen((dirent)->d_name)
+#else
+# define dirent direct
+# define NAMLEN(dirent) (dirent)->d_namlen
+# ifdef HAVE_SYS_NDIR_H
+#  include <sys/ndir.h>
+# endif
+# ifdef HAVE_SYS_DIR_H
+#  include <sys/dir.h>
+# endif
+# ifdef HAVE_NDIR_H
+#  include <ndir.h>
+# endif
+# ifdef HAVE_VMSDIR_H
+#  include "vmsdir.h"
+# endif /* HAVE_VMSDIR_H */
+#endif
+
+
+/* In GNU systems, <dirent.h> defines this macro for us.  */
+#ifdef _D_NAMLEN
+# undef NAMLEN
+# define NAMLEN(d) _D_NAMLEN(d)
+#endif
+
+/* When used in the GNU libc the symbol _DIRENT_HAVE_D_TYPE is available
+   if the `d_type' member for `struct dirent' is available.  */
+#ifdef _DIRENT_HAVE_D_TYPE
+# define HAVE_D_TYPE	1
+#endif
+
+
+#if (defined POSIX || defined WINDOWS32) && !defined __GNU_LIBRARY__
+/* Posix does not require that the d_ino field be present, and some
+   systems do not provide it. */
+# define REAL_DIR_ENTRY(dp) 1
+#else
+# define REAL_DIR_ENTRY(dp) (dp->d_ino != 0)
+#endif /* POSIX */
+
+#if defined STDC_HEADERS || defined __GNU_LIBRARY__
+# include <stdlib.h>
+# include <string.h>
+# define	ANSI_STRING
+#else	/* No standard headers.  */
+
+extern char *getenv ();
+
+# ifdef HAVE_STRING_H
+#  include <string.h>
+#  define ANSI_STRING
+# else
+#  include <strings.h>
+# endif
+# ifdef	HAVE_MEMORY_H
+#  include <memory.h>
+# endif
+
+extern char *malloc (), *realloc ();
+extern void free ();
+
+extern void qsort ();
+extern void abort (), exit ();
+
+#endif	/* Standard headers.  */
+
+#ifndef	ANSI_STRING
+
+# ifndef bzero
+extern void bzero ();
+# endif
+# ifndef bcopy
+extern void bcopy ();
+# endif
+
+# define memcpy(d, s, n)	bcopy ((s), (d), (n))
+# define strrchr	rindex
+/* memset is only used for zero here, but let's be paranoid.  */
+# define memset(s, better_be_zero, n) \
+  ((void) ((better_be_zero) == 0 ? (bzero((s), (n)), 0) : (abort(), 0)))
+#endif	/* Not ANSI_STRING.  */
+
+#if !defined HAVE_STRCOLL && !defined _LIBC
+# define strcoll	strcmp
+#endif
+
+#if !defined HAVE_MEMPCPY && __GLIBC__ - 0 == 2 && __GLIBC_MINOR__ >= 1
+# define HAVE_MEMPCPY	1
+# undef  mempcpy
+# define mempcpy(Dest, Src, Len) __mempcpy (Dest, Src, Len)
+#endif
+
+#ifndef	__GNU_LIBRARY__
+# ifdef	__GNUC__
+__inline
+# endif
+# ifndef __SASC
+#  ifdef WINDOWS32
+static void *
+#  else
+static char *
+# endif
+my_realloc (p, n)
+     char *p;
+     unsigned int n;
+{
+  /* These casts are the for sake of the broken Ultrix compiler,
+     which warns of illegal pointer combinations otherwise.  */
+  if (p == NULL)
+    return (char *) malloc (n);
+  return (char *) realloc (p, n);
+}
+# define	realloc	my_realloc
+# endif /* __SASC */
+#endif /* __GNU_LIBRARY__ */
+
+
+#if !defined __alloca && defined __GNU_LIBRARY__
+
+# ifdef	__GNUC__
+#  undef alloca
+#  define alloca(n)	__builtin_alloca (n)
+# else	/* Not GCC.  */
+#  ifdef HAVE_ALLOCA_H
+#   include <alloca.h>
+#  else	/* Not HAVE_ALLOCA_H.  */
+#   ifndef _AIX
+#    ifdef WINDOWS32
+#     include <malloc.h>
+#    else
+extern char *alloca ();
+#    endif /* WINDOWS32 */
+#   endif /* Not _AIX.  */
+#  endif /* sparc or HAVE_ALLOCA_H.  */
+# endif	/* GCC.  */
+
+# define __alloca	alloca
+
+#endif
+
+#ifndef __GNU_LIBRARY__
+# define __stat stat
+# ifdef STAT_MACROS_BROKEN
+#  undef S_ISDIR
+# endif
+# ifndef S_ISDIR
+#  define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+# endif
+#endif
+
+#ifdef _LIBC
+# undef strdup
+# define strdup(str) __strdup (str)
+# define sysconf(id) __sysconf (id)
+# define closedir(dir) __closedir (dir)
+# define opendir(name) __opendir (name)
+# define readdir(str) __readdir (str)
+# define getpwnam_r(name, bufp, buf, len, res) \
+   __getpwnam_r (name, bufp, buf, len, res)
+# ifndef __stat
+#  define __stat(fname, buf) __xstat (_STAT_VER, fname, buf)
+# endif
+#endif
+
+#if !(defined STDC_HEADERS || defined __GNU_LIBRARY__)
+# undef	size_t
+# define size_t	unsigned int
+#endif
+
+/* Some system header files erroneously define these.
+   We want our own definitions from <fnmatch.h> to take precedence.  */
+#ifndef __GNU_LIBRARY__
+# undef	FNM_PATHNAME
+# undef	FNM_NOESCAPE
+# undef	FNM_PERIOD
+#endif
+#include <fnmatch.h>
+
+/* Some system header files erroneously define these.
+   We want our own definitions from <glob.h> to take precedence.  */
+#ifndef __GNU_LIBRARY__
+# undef	GLOB_ERR
+# undef	GLOB_MARK
+# undef	GLOB_NOSORT
+# undef	GLOB_DOOFFS
+# undef	GLOB_NOCHECK
+# undef	GLOB_APPEND
+# undef	GLOB_NOESCAPE
+# undef	GLOB_PERIOD
+#endif
+#include <glob.h>
+
+#ifdef HAVE_GETLOGIN_R
+extern int getlogin_r __P ((char *, size_t));
+#else
+extern char *getlogin __P ((void));
+#endif
+
+static
+#if __GNUC__ - 0 >= 2
+inline
+#endif
+const char *next_brace_sub __P ((const char *begin));
+static int glob_in_dir __P ((const char *pattern, const char *directory,
+			     int flags,
+			     int (*errfunc) (const char *, int),
+			     glob_t *pglob));
+static int prefix_array __P ((const char *prefix, char **array, size_t n));
+static int collated_compare __P ((const __ptr_t, const __ptr_t));
+
+#ifdef VMS
+/* these compilers like prototypes */
+#if !defined _LIBC || !defined NO_GLOB_PATTERN_P
+int __glob_pattern_p (const char *pattern, int quote);
+#endif
+#endif
+
+/* Find the end of the sub-pattern in a brace expression.  We define
+   this as an inline function if the compiler permits.  */
+static
+#if __GNUC__ - 0 >= 2
+inline
+#endif
+const char *
+next_brace_sub (begin)
+     const char *begin;
+{
+  unsigned int depth = 0;
+  const char *cp = begin;
+
+  while (1)
+    {
+      if (depth == 0)
+	{
+	  if (*cp != ',' && *cp != '}' && *cp != '\0')
+	    {
+	      if (*cp == '{')
+		++depth;
+	      ++cp;
+	      continue;
+	    }
+	}
+      else
+	{
+	  while (*cp != '\0' && (*cp != '}' || depth > 0))
+	    {
+	      if (*cp == '}')
+		--depth;
+	      ++cp;
+	    }
+	  if (*cp == '\0')
+	    /* An incorrectly terminated brace expression.  */
+	    return NULL;
+
+	  continue;
+	}
+      break;
+    }
+
+  return cp;
+}
+
+/* Do glob searching for PATTERN, placing results in PGLOB.
+   The bits defined above may be set in FLAGS.
+   If a directory cannot be opened or read and ERRFUNC is not nil,
+   it is called with the pathname that caused the error, and the
+   `errno' value from the failing call; if it returns non-zero
+   `glob' returns GLOB_ABORTED; if it returns zero, the error is ignored.
+   If memory cannot be allocated for PGLOB, GLOB_NOSPACE is returned.
+   Otherwise, `glob' returns zero.  */
+int
+glob (pattern, flags, errfunc, pglob)
+     const char *pattern;
+     int flags;
+     int (*errfunc) __P ((const char *, int));
+     glob_t *pglob;
+{
+  const char *filename;
+  const char *dirname;
+  size_t dirlen;
+  int status;
+  int oldcount;
+
+  if (pattern == NULL || pglob == NULL || (flags & ~__GLOB_FLAGS) != 0)
+    {
+      __set_errno (EINVAL);
+      return -1;
+    }
+
+  if (flags & GLOB_BRACE)
+    {
+      const char *begin = strchr (pattern, '{');
+      if (begin != NULL)
+	{
+	  /* Allocate working buffer large enough for our work.  Note that
+	    we have at least an opening and closing brace.  */
+	  int firstc;
+	  char *alt_start;
+	  const char *p;
+	  const char *next;
+	  const char *rest;
+	  size_t rest_len;
+#ifdef __GNUC__
+	  char onealt[strlen (pattern) - 1];
+#else
+	  char *onealt = (char *) malloc (strlen (pattern) - 1);
+	  if (onealt == NULL)
+	    {
+	      if (!(flags & GLOB_APPEND))
+		globfree (pglob);
+	      return GLOB_NOSPACE;
+	    }
+#endif
+
+	  /* We know the prefix for all sub-patterns.  */
+#ifdef HAVE_MEMPCPY
+	  alt_start = mempcpy (onealt, pattern, begin - pattern);
+#else
+	  memcpy (onealt, pattern, begin - pattern);
+	  alt_start = &onealt[begin - pattern];
+#endif
+
+	  /* Find the first sub-pattern and at the same time find the
+	     rest after the closing brace.  */
+	  next = next_brace_sub (begin + 1);
+	  if (next == NULL)
+	    {
+	      /* It is an illegal expression.  */
+#ifndef __GNUC__
+	      free (onealt);
+#endif
+	      return glob (pattern, flags & ~GLOB_BRACE, errfunc, pglob);
+	    }
+
+	  /* Now find the end of the whole brace expression.  */
+	  rest = next;
+	  while (*rest != '}')
+	    {
+	      rest = next_brace_sub (rest + 1);
+	      if (rest == NULL)
+		{
+		  /* It is an illegal expression.  */
+#ifndef __GNUC__
+		  free (onealt);
+#endif
+		  return glob (pattern, flags & ~GLOB_BRACE, errfunc, pglob);
+		}
+	    }
+	  /* Please note that we now can be sure the brace expression
+	     is well-formed.  */
+	  rest_len = strlen (++rest) + 1;
+
+	  /* We have a brace expression.  BEGIN points to the opening {,
+	     NEXT points past the terminator of the first element, and END
+	     points past the final }.  We will accumulate result names from
+	     recursive runs for each brace alternative in the buffer using
+	     GLOB_APPEND.  */
+
+	  if (!(flags & GLOB_APPEND))
+	    {
+	      /* This call is to set a new vector, so clear out the
+		 vector so we can append to it.  */
+	      pglob->gl_pathc = 0;
+	      pglob->gl_pathv = NULL;
+	    }
+	  firstc = pglob->gl_pathc;
+
+	  p = begin + 1;
+	  while (1)
+	    {
+	      int result;
+
+	      /* Construct the new glob expression.  */
+#ifdef HAVE_MEMPCPY
+	      mempcpy (mempcpy (alt_start, p, next - p), rest, rest_len);
+#else
+	      memcpy (alt_start, p, next - p);
+	      memcpy (&alt_start[next - p], rest, rest_len);
+#endif
+
+	      result = glob (onealt,
+			     ((flags & ~(GLOB_NOCHECK|GLOB_NOMAGIC))
+			      | GLOB_APPEND), errfunc, pglob);
+
+	      /* If we got an error, return it.  */
+	      if (result && result != GLOB_NOMATCH)
+		{
+#ifndef __GNUC__
+		  free (onealt);
+#endif
+		  if (!(flags & GLOB_APPEND))
+		    globfree (pglob);
+		  return result;
+		}
+
+	      if (*next == '}')
+		/* We saw the last entry.  */
+		break;
+
+	      p = next + 1;
+	      next = next_brace_sub (p);
+	      assert (next != NULL);
+	    }
+
+#ifndef __GNUC__
+	  free (onealt);
+#endif
+
+	  if (pglob->gl_pathc != firstc)
+	    /* We found some entries.  */
+	    return 0;
+	  else if (!(flags & (GLOB_NOCHECK|GLOB_NOMAGIC)))
+	    return GLOB_NOMATCH;
+	}
+    }
+
+  /* Find the filename.  */
+  filename = strrchr (pattern, '/');
+#if defined __MSDOS__ || defined WINDOWS32
+  /* The case of "d:pattern".  Since `:' is not allowed in
+     file names, we can safely assume that wherever it
+     happens in pattern, it signals the filename part.  This
+     is so we could some day support patterns like "[a-z]:foo".  */
+  if (filename == NULL)
+    filename = strchr (pattern, ':');
+#endif /* __MSDOS__ || WINDOWS32 */
+  if (filename == NULL)
+    {
+      /* This can mean two things: a simple name or "~name".  The later
+	 case is nothing but a notation for a directory.  */
+      if ((flags & (GLOB_TILDE|GLOB_TILDE_CHECK)) && pattern[0] == '~')
+	{
+	  dirname = pattern;
+	  dirlen = strlen (pattern);
+
+	  /* Set FILENAME to NULL as a special flag.  This is ugly but
+	     other solutions would require much more code.  We test for
+	     this special case below.  */
+	  filename = NULL;
+	}
+      else
+	{
+	  filename = pattern;
+#ifdef _AMIGA
+	  dirname = "";
+#else
+	  dirname = ".";
+#endif
+	  dirlen = 0;
+	}
+    }
+  else if (filename == pattern)
+    {
+      /* "/pattern".  */
+      dirname = "/";
+      dirlen = 1;
+      ++filename;
+    }
+  else
+    {
+      char *newp;
+      dirlen = filename - pattern;
+#if defined __MSDOS__ || defined WINDOWS32
+      if (*filename == ':'
+	  || (filename > pattern + 1 && filename[-1] == ':'))
+	{
+	  char *drive_spec;
+
+	  ++dirlen;
+	  drive_spec = (char *) __alloca (dirlen + 1);
+#ifdef HAVE_MEMPCPY
+	  *((char *) mempcpy (drive_spec, pattern, dirlen)) = '\0';
+#else
+	  memcpy (drive_spec, pattern, dirlen);
+	  drive_spec[dirlen] = '\0';
+#endif
+	  /* For now, disallow wildcards in the drive spec, to
+	     prevent infinite recursion in glob.  */
+	  if (__glob_pattern_p (drive_spec, !(flags & GLOB_NOESCAPE)))
+	    return GLOB_NOMATCH;
+	  /* If this is "d:pattern", we need to copy `:' to DIRNAME
+	     as well.  If it's "d:/pattern", don't remove the slash
+	     from "d:/", since "d:" and "d:/" are not the same.*/
+	}
+#endif
+      newp = (char *) __alloca (dirlen + 1);
+#ifdef HAVE_MEMPCPY
+      *((char *) mempcpy (newp, pattern, dirlen)) = '\0';
+#else
+      memcpy (newp, pattern, dirlen);
+      newp[dirlen] = '\0';
+#endif
+      dirname = newp;
+      ++filename;
+
+      if (filename[0] == '\0'
+#if defined __MSDOS__ || defined WINDOWS32
+          && dirname[dirlen - 1] != ':'
+	  && (dirlen < 3 || dirname[dirlen - 2] != ':'
+	      || dirname[dirlen - 1] != '/')
+#endif
+	  && dirlen > 1)
+	/* "pattern/".  Expand "pattern", appending slashes.  */
+	{
+	  int val = glob (dirname, flags | GLOB_MARK, errfunc, pglob);
+	  if (val == 0)
+	    pglob->gl_flags = ((pglob->gl_flags & ~GLOB_MARK)
+			       | (flags & GLOB_MARK));
+	  return val;
+	}
+    }
+
+  if (!(flags & GLOB_APPEND))
+    {
+      pglob->gl_pathc = 0;
+      pglob->gl_pathv = NULL;
+    }
+
+  oldcount = pglob->gl_pathc;
+
+#ifndef VMS
+  if ((flags & (GLOB_TILDE|GLOB_TILDE_CHECK)) && dirname[0] == '~')
+    {
+      if (dirname[1] == '\0' || dirname[1] == '/')
+	{
+	  /* Look up home directory.  */
+#ifdef VMS
+/* This isn't obvious, RTLs of DECC and VAXC know about "HOME" */
+          const char *home_dir = getenv ("SYS$LOGIN");
+#else
+          const char *home_dir = getenv ("HOME");
+#endif
+# ifdef _AMIGA
+	  if (home_dir == NULL || home_dir[0] == '\0')
+	    home_dir = "SYS:";
+# else
+#  ifdef WINDOWS32
+	  if (home_dir == NULL || home_dir[0] == '\0')
+            home_dir = "c:/users/default"; /* poor default */
+#  else
+#   ifdef VMS
+/* Again, this isn't obvious, if "HOME" isn't known "SYS$LOGIN" should be set */
+	  if (home_dir == NULL || home_dir[0] == '\0')
+	    home_dir = "SYS$DISK:[]";
+#   else
+	  if (home_dir == NULL || home_dir[0] == '\0')
+	    {
+	      int success;
+	      char *name;
+#   if defined HAVE_GETLOGIN_R || defined _LIBC
+	      size_t buflen = sysconf (_SC_LOGIN_NAME_MAX) + 1;
+
+	      if (buflen == 0)
+		/* `sysconf' does not support _SC_LOGIN_NAME_MAX.  Try
+		   a moderate value.  */
+		buflen = 20;
+	      name = (char *) __alloca (buflen);
+
+	      success = getlogin_r (name, buflen) >= 0;
+#   else
+	      success = (name = getlogin ()) != NULL;
+#   endif
+	      if (success)
+		{
+		  struct passwd *p;
+#   if defined HAVE_GETPWNAM_R || defined _LIBC
+		  size_t pwbuflen = sysconf (_SC_GETPW_R_SIZE_MAX);
+		  char *pwtmpbuf;
+		  struct passwd pwbuf;
+		  int save = errno;
+
+		  if (pwbuflen == -1)
+		    /* `sysconf' does not support _SC_GETPW_R_SIZE_MAX.
+		       Try a moderate value.  */
+		    pwbuflen = 1024;
+		  pwtmpbuf = (char *) __alloca (pwbuflen);
+
+		  while (getpwnam_r (name, &pwbuf, pwtmpbuf, pwbuflen, &p)
+			 != 0)
+		    {
+		      if (errno != ERANGE)
+			{
+			  p = NULL;
+			  break;
+			}
+		      pwbuflen *= 2;
+		      pwtmpbuf = (char *) __alloca (pwbuflen);
+		      __set_errno (save);
+		    }
+#   else
+		  p = getpwnam (name);
+#   endif
+		  if (p != NULL)
+		    home_dir = p->pw_dir;
+		}
+	    }
+	  if (home_dir == NULL || home_dir[0] == '\0')
+	    {
+	      if (flags & GLOB_TILDE_CHECK)
+		return GLOB_NOMATCH;
+	      else
+		home_dir = "~"; /* No luck.  */
+	    }
+#   endif /* VMS */
+#  endif /* WINDOWS32 */
+# endif
+	  /* Now construct the full directory.  */
+	  if (dirname[1] == '\0')
+	    dirname = home_dir;
+	  else
+	    {
+	      char *newp;
+	      size_t home_len = strlen (home_dir);
+	      newp = (char *) __alloca (home_len + dirlen);
+# ifdef HAVE_MEMPCPY
+	      mempcpy (mempcpy (newp, home_dir, home_len),
+		       &dirname[1], dirlen);
+# else
+	      memcpy (newp, home_dir, home_len);
+	      memcpy (&newp[home_len], &dirname[1], dirlen);
+# endif
+	      dirname = newp;
+	    }
+	}
+# if !defined _AMIGA && !defined WINDOWS32 && !defined VMS
+      else
+	{
+	  char *end_name = strchr (dirname, '/');
+	  const char *user_name;
+	  const char *home_dir;
+
+	  if (end_name == NULL)
+	    user_name = dirname + 1;
+	  else
+	    {
+	      char *newp;
+	      newp = (char *) __alloca (end_name - dirname);
+# ifdef HAVE_MEMPCPY
+	      *((char *) mempcpy (newp, dirname + 1, end_name - dirname))
+		= '\0';
+# else
+	      memcpy (newp, dirname + 1, end_name - dirname);
+	      newp[end_name - dirname - 1] = '\0';
+# endif
+	      user_name = newp;
+	    }
+
+	  /* Look up specific user's home directory.  */
+	  {
+	    struct passwd *p;
+#  if defined HAVE_GETPWNAM_R || defined _LIBC
+	    size_t buflen = sysconf (_SC_GETPW_R_SIZE_MAX);
+	    char *pwtmpbuf;
+	    struct passwd pwbuf;
+	    int save = errno;
+
+	    if (buflen == -1)
+	      /* `sysconf' does not support _SC_GETPW_R_SIZE_MAX.  Try a
+		 moderate value.  */
+	      buflen = 1024;
+	    pwtmpbuf = (char *) __alloca (buflen);
+
+	    while (getpwnam_r (user_name, &pwbuf, pwtmpbuf, buflen, &p) != 0)
+	      {
+		if (errno != ERANGE)
+		  {
+		    p = NULL;
+		    break;
+		  }
+		buflen *= 2;
+		pwtmpbuf = __alloca (buflen);
+		__set_errno (save);
+	      }
+#  else
+	    p = getpwnam (user_name);
+#  endif
+	    if (p != NULL)
+	      home_dir = p->pw_dir;
+	    else
+	      home_dir = NULL;
+	  }
+	  /* If we found a home directory use this.  */
+	  if (home_dir != NULL)
+	    {
+	      char *newp;
+	      size_t home_len = strlen (home_dir);
+	      size_t rest_len = end_name == NULL ? 0 : strlen (end_name);
+	      newp = (char *) __alloca (home_len + rest_len + 1);
+#  ifdef HAVE_MEMPCPY
+	      *((char *) mempcpy (mempcpy (newp, home_dir, home_len),
+				  end_name, rest_len)) = '\0';
+#  else
+	      memcpy (newp, home_dir, home_len);
+	      memcpy (&newp[home_len], end_name, rest_len);
+	      newp[home_len + rest_len] = '\0';
+#  endif
+	      dirname = newp;
+	    }
+	  else
+	    if (flags & GLOB_TILDE_CHECK)
+	      /* We have to regard it as an error if we cannot find the
+		 home directory.  */
+	      return GLOB_NOMATCH;
+	}
+# endif	/* Not Amiga && not WINDOWS32 && not VMS.  */
+    }
+#endif	/* Not VMS.  */
+
+  /* Now test whether we looked for "~" or "~NAME".  In this case we
+     can give the answer now.  */
+  if (filename == NULL)
+    {
+      struct stat st;
+
+      /* Return the directory if we don't check for error or if it exists.  */
+      if ((flags & GLOB_NOCHECK)
+	  || (((flags & GLOB_ALTDIRFUNC)
+	       ? (*pglob->gl_stat) (dirname, &st)
+	       : __stat (dirname, &st)) == 0
+	      && S_ISDIR (st.st_mode)))
+	{
+	  pglob->gl_pathv
+	    = (char **) realloc (pglob->gl_pathv,
+				 (pglob->gl_pathc +
+				  ((flags & GLOB_DOOFFS) ?
+				   pglob->gl_offs : 0) +
+				  1 + 1) *
+				 sizeof (char *));
+	  if (pglob->gl_pathv == NULL)
+	    return GLOB_NOSPACE;
+
+	  if (flags & GLOB_DOOFFS)
+	    while (pglob->gl_pathc < pglob->gl_offs)
+	      pglob->gl_pathv[pglob->gl_pathc++] = NULL;
+
+#if defined HAVE_STRDUP || defined _LIBC
+	  pglob->gl_pathv[pglob->gl_pathc] = strdup (dirname);
+#else
+	  {
+	    size_t len = strlen (dirname) + 1;
+	    char *dircopy = malloc (len);
+	    if (dircopy != NULL)
+	      pglob->gl_pathv[pglob->gl_pathc] = memcpy (dircopy, dirname,
+							 len);
+	  }
+#endif
+	  if (pglob->gl_pathv[pglob->gl_pathc] == NULL)
+	    {
+	      free (pglob->gl_pathv);
+	      return GLOB_NOSPACE;
+	    }
+	  pglob->gl_pathv[++pglob->gl_pathc] = NULL;
+	  pglob->gl_flags = flags;
+
+	  return 0;
+	}
+
+      /* Not found.  */
+      return GLOB_NOMATCH;
+    }
+
+  if (__glob_pattern_p (dirname, !(flags & GLOB_NOESCAPE)))
+    {
+      /* The directory name contains metacharacters, so we
+	 have to glob for the directory, and then glob for
+	 the pattern in each directory found.  */
+      glob_t dirs;
+      register int i;
+
+      status = glob (dirname,
+		     ((flags & (GLOB_ERR | GLOB_NOCHECK | GLOB_NOESCAPE))
+		      | GLOB_NOSORT | GLOB_ONLYDIR),
+		     errfunc, &dirs);
+      if (status != 0)
+	return status;
+
+      /* We have successfully globbed the preceding directory name.
+	 For each name we found, call glob_in_dir on it and FILENAME,
+	 appending the results to PGLOB.  */
+      for (i = 0; i < dirs.gl_pathc; ++i)
+	{
+	  int old_pathc;
+
+#ifdef	SHELL
+	  {
+	    /* Make globbing interruptible in the bash shell. */
+	    extern int interrupt_state;
+
+	    if (interrupt_state)
+	      {
+		globfree (&dirs);
+		globfree (&files);
+		return GLOB_ABORTED;
+	      }
+	  }
+#endif /* SHELL.  */
+
+	  old_pathc = pglob->gl_pathc;
+	  status = glob_in_dir (filename, dirs.gl_pathv[i],
+				((flags | GLOB_APPEND)
+				 & ~(GLOB_NOCHECK | GLOB_ERR)),
+				errfunc, pglob);
+	  if (status == GLOB_NOMATCH)
+	    /* No matches in this directory.  Try the next.  */
+	    continue;
+
+	  if (status != 0)
+	    {
+	      globfree (&dirs);
+	      globfree (pglob);
+	      return status;
+	    }
+
+	  /* Stick the directory on the front of each name.  */
+	  if (prefix_array (dirs.gl_pathv[i],
+			    &pglob->gl_pathv[old_pathc],
+			    pglob->gl_pathc - old_pathc))
+	    {
+	      globfree (&dirs);
+	      globfree (pglob);
+	      return GLOB_NOSPACE;
+	    }
+	}
+
+      flags |= GLOB_MAGCHAR;
+
+      /* We have ignored the GLOB_NOCHECK flag in the `glob_in_dir' calls.
+	 But if we have not found any matching entry and thie GLOB_NOCHECK
+	 flag was set we must return the list consisting of the disrectory
+	 names followed by the filename.  */
+      if (pglob->gl_pathc == oldcount)
+	{
+	  /* No matches.  */
+	  if (flags & GLOB_NOCHECK)
+	    {
+	      size_t filename_len = strlen (filename) + 1;
+	      char **new_pathv;
+	      struct stat st;
+
+	      /* This is an pessimistic guess about the size.  */
+	      pglob->gl_pathv
+		= (char **) realloc (pglob->gl_pathv,
+				     (pglob->gl_pathc +
+				      ((flags & GLOB_DOOFFS) ?
+				       pglob->gl_offs : 0) +
+				      dirs.gl_pathc + 1) *
+				     sizeof (char *));
+	      if (pglob->gl_pathv == NULL)
+		{
+		  globfree (&dirs);
+		  return GLOB_NOSPACE;
+		}
+
+	      if (flags & GLOB_DOOFFS)
+		while (pglob->gl_pathc < pglob->gl_offs)
+		  pglob->gl_pathv[pglob->gl_pathc++] = NULL;
+
+	      for (i = 0; i < dirs.gl_pathc; ++i)
+		{
+		  const char *dir = dirs.gl_pathv[i];
+		  size_t dir_len = strlen (dir);
+
+		  /* First check whether this really is a directory.  */
+		  if (((flags & GLOB_ALTDIRFUNC)
+		       ? (*pglob->gl_stat) (dir, &st) : __stat (dir, &st)) != 0
+		      || !S_ISDIR (st.st_mode))
+		    /* No directory, ignore this entry.  */
+		    continue;
+
+		  pglob->gl_pathv[pglob->gl_pathc] = malloc (dir_len + 1
+							     + filename_len);
+		  if (pglob->gl_pathv[pglob->gl_pathc] == NULL)
+		    {
+		      globfree (&dirs);
+		      globfree (pglob);
+		      return GLOB_NOSPACE;
+		    }
+
+#ifdef HAVE_MEMPCPY
+		  mempcpy (mempcpy (mempcpy (pglob->gl_pathv[pglob->gl_pathc],
+					     dir, dir_len),
+				    "/", 1),
+			   filename, filename_len);
+#else
+		  memcpy (pglob->gl_pathv[pglob->gl_pathc], dir, dir_len);
+		  pglob->gl_pathv[pglob->gl_pathc][dir_len] = '/';
+		  memcpy (&pglob->gl_pathv[pglob->gl_pathc][dir_len + 1],
+			  filename, filename_len);
+#endif
+		  ++pglob->gl_pathc;
+		}
+
+	      pglob->gl_pathv[pglob->gl_pathc] = NULL;
+	      pglob->gl_flags = flags;
+
+	      /* Now we know how large the gl_pathv vector must be.  */
+	      new_pathv = (char **) realloc (pglob->gl_pathv,
+					     ((pglob->gl_pathc + 1)
+					      * sizeof (char *)));
+	      if (new_pathv != NULL)
+		pglob->gl_pathv = new_pathv;
+	    }
+	  else
+	    return GLOB_NOMATCH;
+	}
+
+      globfree (&dirs);
+    }
+  else
+    {
+      status = glob_in_dir (filename, dirname, flags, errfunc, pglob);
+      if (status != 0)
+	return status;
+
+      if (dirlen > 0)
+	{
+	  /* Stick the directory on the front of each name.  */
+	  int ignore = oldcount;
+
+	  if ((flags & GLOB_DOOFFS) && ignore < pglob->gl_offs)
+	    ignore = pglob->gl_offs;
+
+	  if (prefix_array (dirname,
+			    &pglob->gl_pathv[ignore],
+			    pglob->gl_pathc - ignore))
+	    {
+	      globfree (pglob);
+	      return GLOB_NOSPACE;
+	    }
+	}
+    }
+
+  if (flags & GLOB_MARK)
+    {
+      /* Append slashes to directory names.  */
+      int i;
+      struct stat st;
+      for (i = oldcount; i < pglob->gl_pathc; ++i)
+	if (((flags & GLOB_ALTDIRFUNC)
+	     ? (*pglob->gl_stat) (pglob->gl_pathv[i], &st)
+	     : __stat (pglob->gl_pathv[i], &st)) == 0
+	    && S_ISDIR (st.st_mode))
+	  {
+ 	    size_t len = strlen (pglob->gl_pathv[i]) + 2;
+	    char *new = realloc (pglob->gl_pathv[i], len);
+ 	    if (new == NULL)
+	      {
+		globfree (pglob);
+		return GLOB_NOSPACE;
+	      }
+	    strcpy (&new[len - 2], "/");
+	    pglob->gl_pathv[i] = new;
+	  }
+    }
+
+  if (!(flags & GLOB_NOSORT))
+    {
+      /* Sort the vector.  */
+      int non_sort = oldcount;
+
+      if ((flags & GLOB_DOOFFS) && pglob->gl_offs > oldcount)
+	non_sort = pglob->gl_offs;
+
+      qsort ((__ptr_t) &pglob->gl_pathv[non_sort],
+	     pglob->gl_pathc - non_sort,
+	     sizeof (char *), collated_compare);
+    }
+
+  return 0;
+}
+
+
+/* Free storage allocated in PGLOB by a previous `glob' call.  */
+void
+globfree (pglob)
+     register glob_t *pglob;
+{
+  if (pglob->gl_pathv != NULL)
+    {
+      register int i;
+      for (i = 0; i < pglob->gl_pathc; ++i)
+	if (pglob->gl_pathv[i] != NULL)
+	  free ((__ptr_t) pglob->gl_pathv[i]);
+      free ((__ptr_t) pglob->gl_pathv);
+    }
+}
+
+
+/* Do a collated comparison of A and B.  */
+static int
+collated_compare (a, b)
+     const __ptr_t a;
+     const __ptr_t b;
+{
+  const char *const s1 = *(const char *const * const) a;
+  const char *const s2 = *(const char *const * const) b;
+
+  if (s1 == s2)
+    return 0;
+  if (s1 == NULL)
+    return 1;
+  if (s2 == NULL)
+    return -1;
+  return strcoll (s1, s2);
+}
+
+
+/* Prepend DIRNAME to each of N members of ARRAY, replacing ARRAY's
+   elements in place.  Return nonzero if out of memory, zero if successful.
+   A slash is inserted between DIRNAME and each elt of ARRAY,
+   unless DIRNAME is just "/".  Each old element of ARRAY is freed.  */
+static int
+prefix_array (dirname, array, n)
+     const char *dirname;
+     char **array;
+     size_t n;
+{
+  register size_t i;
+  size_t dirlen = strlen (dirname);
+#if defined __MSDOS__ || defined WINDOWS32
+  int sep_char = '/';
+# define DIRSEP_CHAR sep_char
+#else
+# define DIRSEP_CHAR '/'
+#endif
+
+  if (dirlen == 1 && dirname[0] == '/')
+    /* DIRNAME is just "/", so normal prepending would get us "//foo".
+       We want "/foo" instead, so don't prepend any chars from DIRNAME.  */
+    dirlen = 0;
+#if defined __MSDOS__ || defined WINDOWS32
+  else if (dirlen > 1)
+    {
+      if (dirname[dirlen - 1] == '/' && dirname[dirlen - 2] == ':')
+	/* DIRNAME is "d:/".  Don't prepend the slash from DIRNAME.  */
+	--dirlen;
+      else if (dirname[dirlen - 1] == ':')
+	{
+	  /* DIRNAME is "d:".  Use `:' instead of `/'.  */
+	  --dirlen;
+	  sep_char = ':';
+	}
+    }
+#endif
+
+  for (i = 0; i < n; ++i)
+    {
+      size_t eltlen = strlen (array[i]) + 1;
+      char *new = (char *) malloc (dirlen + 1 + eltlen);
+      if (new == NULL)
+	{
+	  while (i > 0)
+	    free ((__ptr_t) array[--i]);
+	  return 1;
+	}
+
+#ifdef HAVE_MEMPCPY
+      {
+	char *endp = (char *) mempcpy (new, dirname, dirlen);
+	*endp++ = DIRSEP_CHAR;
+	mempcpy (endp, array[i], eltlen);
+      }
+#else
+      memcpy (new, dirname, dirlen);
+      new[dirlen] = DIRSEP_CHAR;
+      memcpy (&new[dirlen + 1], array[i], eltlen);
+#endif
+      free ((__ptr_t) array[i]);
+      array[i] = new;
+    }
+
+  return 0;
+}
+
+
+/* We must not compile this function twice.  */
+#if !defined _LIBC || !defined NO_GLOB_PATTERN_P
+/* Return nonzero if PATTERN contains any metacharacters.
+   Metacharacters can be quoted with backslashes if QUOTE is nonzero.  */
+int
+__glob_pattern_p (pattern, quote)
+     const char *pattern;
+     int quote;
+{
+  register const char *p;
+  int open = 0;
+
+  for (p = pattern; *p != '\0'; ++p)
+    switch (*p)
+      {
+      case '?':
+      case '*':
+	return 1;
+
+      case '\\':
+	if (quote && p[1] != '\0')
+	  ++p;
+	break;
+
+      case '[':
+	open = 1;
+	break;
+
+      case ']':
+	if (open)
+	  return 1;
+	break;
+      }
+
+  return 0;
+}
+# ifdef _LIBC
+weak_alias (__glob_pattern_p, glob_pattern_p)
+# endif
+#endif
+
+
+/* Like `glob', but PATTERN is a final pathname component,
+   and matches are searched for in DIRECTORY.
+   The GLOB_NOSORT bit in FLAGS is ignored.  No sorting is ever done.
+   The GLOB_APPEND flag is assumed to be set (always appends).  */
+static int
+glob_in_dir (pattern, directory, flags, errfunc, pglob)
+     const char *pattern;
+     const char *directory;
+     int flags;
+     int (*errfunc) __P ((const char *, int));
+     glob_t *pglob;
+{
+  __ptr_t stream = NULL;
+
+  struct globlink
+    {
+      struct globlink *next;
+      char *name;
+    };
+  struct globlink *names = NULL;
+  size_t nfound;
+  int meta;
+  int save;
+
+#ifdef VMS
+  if (*directory == 0)
+    directory = "[]";
+#endif
+  meta = __glob_pattern_p (pattern, !(flags & GLOB_NOESCAPE));
+  if (meta == 0)
+    {
+      if (flags & (GLOB_NOCHECK|GLOB_NOMAGIC))
+	/* We need not do any tests.  The PATTERN contains no meta
+	   characters and we must not return an error therefore the
+	   result will always contain exactly one name.  */
+	flags |= GLOB_NOCHECK;
+      else
+	{
+	  /* Since we use the normal file functions we can also use stat()
+	     to verify the file is there.  */
+	  struct stat st;
+	  size_t patlen = strlen (pattern);
+	  size_t dirlen = strlen (directory);
+	  char *fullname = (char *) __alloca (dirlen + 1 + patlen + 1);
+
+# ifdef HAVE_MEMPCPY
+	  mempcpy (mempcpy (mempcpy (fullname, directory, dirlen),
+			    "/", 1),
+		   pattern, patlen + 1);
+# else
+	  memcpy (fullname, directory, dirlen);
+	  fullname[dirlen] = '/';
+	  memcpy (&fullname[dirlen + 1], pattern, patlen + 1);
+# endif
+	  if (((flags & GLOB_ALTDIRFUNC)
+	       ? (*pglob->gl_stat) (fullname, &st)
+	       : __stat (fullname, &st)) == 0)
+	    /* We found this file to be existing.  Now tell the rest
+	       of the function to copy this name into the result.  */
+	    flags |= GLOB_NOCHECK;
+	}
+
+      nfound = 0;
+    }
+  else
+    {
+      if (pattern[0] == '\0')
+	{
+	  /* This is a special case for matching directories like in
+	     "*a/".  */
+	  names = (struct globlink *) __alloca (sizeof (struct globlink));
+	  names->name = (char *) malloc (1);
+	  if (names->name == NULL)
+	    goto memory_error;
+	  names->name[0] = '\0';
+	  names->next = NULL;
+	  nfound = 1;
+	  meta = 0;
+	}
+      else
+	{
+	  stream = ((flags & GLOB_ALTDIRFUNC)
+		    ? (*pglob->gl_opendir) (directory)
+		    : (__ptr_t) opendir (directory));
+	  if (stream == NULL)
+	    {
+	      if (errno != ENOTDIR
+		  && ((errfunc != NULL && (*errfunc) (directory, errno))
+		      || (flags & GLOB_ERR)))
+		return GLOB_ABORTED;
+	      nfound = 0;
+	      meta = 0;
+	    }
+	  else
+	    {
+	      int fnm_flags = ((!(flags & GLOB_PERIOD) ? FNM_PERIOD : 0)
+			       | ((flags & GLOB_NOESCAPE) ? FNM_NOESCAPE : 0)
+#if defined _AMIGA || defined VMS
+				   | FNM_CASEFOLD
+#endif
+				   );
+	      nfound = 0;
+	      flags |= GLOB_MAGCHAR;
+
+	      while (1)
+		{
+		  const char *name;
+		  size_t len;
+		  struct dirent *d = ((flags & GLOB_ALTDIRFUNC)
+				      ? (*pglob->gl_readdir) (stream)
+				      : readdir ((DIR *) stream));
+		  if (d == NULL)
+		    break;
+		  if (! REAL_DIR_ENTRY (d))
+		    continue;
+
+#ifdef HAVE_D_TYPE
+		  /* If we shall match only directories use the information
+		     provided by the dirent call if possible.  */
+		  if ((flags & GLOB_ONLYDIR)
+		      && d->d_type != DT_UNKNOWN && d->d_type != DT_DIR)
+		    continue;
+#endif
+
+		  name = d->d_name;
+
+		  if (fnmatch (pattern, name, fnm_flags) == 0)
+		    {
+		      struct globlink *new = (struct globlink *)
+			__alloca (sizeof (struct globlink));
+		      len = NAMLEN (d);
+		      new->name = (char *) malloc (len + 1);
+		      if (new->name == NULL)
+			goto memory_error;
+#ifdef HAVE_MEMPCPY
+		      *((char *) mempcpy ((__ptr_t) new->name, name, len))
+			= '\0';
+#else
+		      memcpy ((__ptr_t) new->name, name, len);
+		      new->name[len] = '\0';
+#endif
+		      new->next = names;
+		      names = new;
+		      ++nfound;
+		    }
+		}
+	    }
+	}
+    }
+
+  if (nfound == 0 && (flags & GLOB_NOCHECK))
+    {
+      size_t len = strlen (pattern);
+      nfound = 1;
+      names = (struct globlink *) __alloca (sizeof (struct globlink));
+      names->next = NULL;
+      names->name = (char *) malloc (len + 1);
+      if (names->name == NULL)
+	goto memory_error;
+#ifdef HAVE_MEMPCPY
+      *((char *) mempcpy (names->name, pattern, len)) = '\0';
+#else
+      memcpy (names->name, pattern, len);
+      names->name[len] = '\0';
+#endif
+    }
+
+  if (nfound != 0)
+    {
+      pglob->gl_pathv
+	= (char **) realloc (pglob->gl_pathv,
+			     (pglob->gl_pathc +
+			      ((flags & GLOB_DOOFFS) ? pglob->gl_offs : 0) +
+			      nfound + 1) *
+			     sizeof (char *));
+      if (pglob->gl_pathv == NULL)
+	goto memory_error;
+
+      if (flags & GLOB_DOOFFS)
+	while (pglob->gl_pathc < pglob->gl_offs)
+	  pglob->gl_pathv[pglob->gl_pathc++] = NULL;
+
+      for (; names != NULL; names = names->next)
+	pglob->gl_pathv[pglob->gl_pathc++] = names->name;
+      pglob->gl_pathv[pglob->gl_pathc] = NULL;
+
+      pglob->gl_flags = flags;
+    }
+
+  save = errno;
+  if (stream != NULL)
+    {
+      if (flags & GLOB_ALTDIRFUNC)
+	(*pglob->gl_closedir) (stream);
+      else
+	closedir ((DIR *) stream);
+    }
+  __set_errno (save);
+
+  return nfound == 0 ? GLOB_NOMATCH : 0;
+
+ memory_error:
+  {
+    int save = errno;
+    if (flags & GLOB_ALTDIRFUNC)
+      (*pglob->gl_closedir) (stream);
+    else
+      closedir ((DIR *) stream);
+    __set_errno (save);
+  }
+  while (names != NULL)
+    {
+      if (names->name != NULL)
+	free ((__ptr_t) names->name);
+      names = names->next;
+    }
+  return GLOB_NOSPACE;
+}
+
+#endif	/* Not ELIDE_CODE.  */

--- a/src/arm-ubuntu-spec-2006/files/makedepend.SH
+++ b/src/arm-ubuntu-spec-2006/files/makedepend.SH
@@ -1,0 +1,255 @@
+#! /bin/sh
+case $PERL_CONFIG_SH in
+'')
+	if test -f config.sh; then TOP=.;
+	elif test -f ../config.sh; then TOP=..;
+	elif test -f ../../config.sh; then TOP=../..;
+	elif test -f ../../../config.sh; then TOP=../../..;
+	elif test -f ../../../../config.sh; then TOP=../../../..;
+	else
+		echo "Can't find config.sh."; exit 1
+	fi
+	. $TOP/config.sh
+	;;
+esac
+: This forces SH files to create target in same directory as SH file.
+: This is so that make depend always knows where to find SH derivatives.
+case "$0" in
+*/*) cd `expr X$0 : 'X\(.*\)/'` ;;
+esac
+
+echo "Extracting makedepend (with variable substitutions)"
+rm -f makedepend
+$spitshell >makedepend <<!GROK!THIS!
+$startsh
+# makedepend.SH
+#
+MAKE=$make
+trnl='$trnl'
+!GROK!THIS!
+$spitshell >>makedepend <<'!NO!SUBS!'
+
+if test -d .depending; then
+	echo "$0: Already running, exiting."
+	exit 0
+fi
+
+mkdir .depending
+
+# This script should be called with 
+#     sh ./makedepend MAKE=$(MAKE)
+case "$1" in 
+	MAKE=*) eval $1 ;;
+esac
+
+export PATH || (echo "OOPS, this isn't sh.  Desperation time.  I will feed myself to sh."; sh \$0; kill \$\$)
+
+case $PERL_CONFIG_SH in
+'')
+	if test -f config.sh; then TOP=.;
+	elif test -f ../config.sh; then TOP=..;
+	elif test -f ../../config.sh; then TOP=../..;
+	elif test -f ../../../config.sh; then TOP=../../..;
+	elif test -f ../../../../config.sh; then TOP=../../../..;
+	else
+		echo "Can't find config.sh."; exit 1
+	fi
+	. $TOP/config.sh
+	;;
+esac
+
+# Avoid localized gcc messages
+case "$ccname" in
+    gcc) LC_ALL=C ; export LC_ALL ;;
+esac
+
+# We need .. when we are in the x2p directory if we are using the
+# cppstdin wrapper script.
+# Put .. and . first so that we pick up the present cppstdin, not
+# an older one lying about in /usr/local/bin.
+PATH=".$path_sep..$path_sep$PATH"
+export PATH
+
+case "$osname" in
+amigaos) cat=/bin/cat ;; # must be absolute
+esac
+
+$cat /dev/null >.deptmp
+$rm -f *.c.c c/*.c.c
+if test -f Makefile; then
+    rm -f $firstmakefile
+    cp Makefile $firstmakefile
+    # On QNX, 'cp' preserves timestamp, so $firstmakefile appears
+    # to be out of date.  I don't know if OS/2 has touch, so do this:
+    case "$osname" in
+    os2) ;;
+    netbsd) ;;
+    *) $touch $firstmakefile ;;
+    esac
+fi
+mf=$firstmakefile
+if test -f $mf; then
+    defrule=`<$mf sed -n		\
+	-e '/^\.c\$(OBJ_EXT):.*;/{'	\
+	-e    's/\$\*\.c//'		\
+	-e    's/^[^;]*;[	 ]*//p'	\
+	-e    q				\
+	-e '}'				\
+	-e '/^\.c\$(OBJ_EXT): *$/{'	\
+	-e    N				\
+	-e    's/\$\*\.c//'		\
+	-e    's/^.*\n[	 ]*//p'		\
+	-e    q				\
+	-e '}'`
+fi
+case "$defrule" in
+'') defrule='$(CC) -c $(CFLAGS)' ;;
+esac
+
+: Create files in UU directory to avoid problems with long filenames
+: on systems with 14 character filename limits so file.c.c and file.c
+: might be identical
+$test -d UU || mkdir UU
+
+$MAKE clist || ($echo "Searching for .c files..."; \
+	$echo *.c | $tr ' ' $trnl | $egrep -v '\*' >.clist)
+for file in `$cat .clist`; do
+# for file in `cat /dev/null`; do
+    case "$osname" in
+    uwin)     uwinfix="-e s,\\\\\\\\,/,g -e s,\\([a-zA-Z]\\):/,/\\1/,g" ;;
+    os2)      uwinfix="-e s,\\\\\\\\,/,g" ;;
+    cygwin)   uwinfix="-e s,\\\\\\\\,/,g" ;;
+    posix-bc) uwinfix="-e s/\\*POSIX(\\(.*\\))/\\1/" ;;
+    vos)      uwinfix="-e s/\#/\\\#/" ;;
+    *)        uwinfix="" ;;
+    esac
+    case "$file" in
+    *.c) filebase=`basename $file .c` ;;
+    *.y) filebase=`basename $file .y` ;;
+    esac
+    case "$file" in
+    */*) finc="-I`echo $file | sed 's#/[^/]*$##`" ;;
+    *)   finc= ;;
+    esac
+    $echo "Finding dependencies for $filebase$_o."
+    ( $echo "#line 1 \"$file\""; \
+      $sed -n <$file \
+	-e "/^${filebase}_init(/q" \
+	-e '/^#line/d' \
+	-e '/^#/{' \
+	-e 's|/\*.*$||' \
+	-e 's|\\$||' \
+	-e p \
+	-e '}' ) >UU/$file.c
+
+    if [ "$osname" = os390 -a "$file" = perly.c ]; then
+        $echo '#endif' >>UU/$file.c
+    fi
+
+    if [ "$osname" = os390 ]; then
+        $cppstdin $finc -I. $cppflags $cppminus <UU/$file.c |
+        $sed \
+    	    -e '/^#.*<stdin>/d' \
+	    -e '/^#.*"-"/d' \
+	    -e 's#\.[0-9][0-9]*\.c#'"$file.c#" \
+	    -e 's/^[	 ]*#[	 ]*line/#/' \
+	    -e '/^# *[0-9][0-9]* *[".\/]/!d' \
+	    -e 's/^.*"\(.*\)".*$/'$filebase'\$(OBJ_EXT): \1/' \
+	    -e 's/^# *[0-9][0-9]* \(.*\)$/'$filebase'\$(OBJ_EXT): \1/' \
+	    -e 's|: \./|: |' \
+	    -e 's|\.c\.c|.c|' $uwinfix | \
+        $uniq | $sort | $uniq >> .deptmp
+    else
+        $cppstdin $finc -I. $cppflags $cppminus <UU/$file.c >.cout 2>.cerr
+        $sed \
+	    -e '1d' \
+	    -e '/^#.*<stdin>/d' \
+            -e '/^#.*<builtin>/d' \
+            -e '/^#.*<built-in>/d' \
+            -e '/^#.*<command line>/d' \
+            -e '/^#.*<command-line>/d' \
+	    -e '/^#.*"-"/d' \
+	    -e '/: file path prefix .* never used$/d' \
+	    -e 's#\.[0-9][0-9]*\.c#'"$file.c#" \
+	    -e 's/^[	 ]*#[	 ]*line/#/' \
+	    -e '/^# *[0-9][0-9]* *[".\/]/!d' \
+	    -e 's/^.*"\(.*\)".*$/'$filebase'\$(OBJ_EXT): \1/' \
+	    -e 's/^# *[0-9][0-9]* \(.*\)$/'$filebase'\$(OBJ_EXT): \1/' \
+	    -e 's|: \./|: |' \
+           -e 's|\.c\.c|.c|' $uwinfix .cout .cerr| \
+        $uniq | $sort | $uniq >> .deptmp
+    fi
+done
+
+$sed <$mf >$mf.new -e '1,/^# AUTOMATICALLY/!d'
+
+$MAKE shlist || ($echo "Searching for .SH files..."; \
+	$echo *.SH | $tr ' ' $trnl | $egrep -v '\*' >.shlist)
+
+# Now extract the dependencies on makedepend.SH and Makefile.SH
+# (they should reside in the main Makefile):
+rm -f .shlist.old
+mv .shlist .shlist.old
+$egrep -v '^makedepend\.SH' <.shlist.old >.shlist
+rm -f .shlist.old
+mv .shlist .shlist.old
+$egrep -v '^Makefile\.SH' <.shlist.old >.shlist
+rm -f .shlist.old
+mv .shlist .shlist.old
+$egrep -v '^perl_exp\.SH' <.shlist.old >.shlist
+rm -f .shlist.old
+mv .shlist .shlist.old
+$egrep -v '^config_h\.SH' <.shlist.old >.shlist
+rm .shlist.old
+
+if $test -s .deptmp; then
+    for file in `cat .shlist`; do
+	$echo `$expr X$file : 'X\(.*\).SH'`: $file $TOP/config.sh \; \
+	    $sh $file >> .deptmp
+    done
+    $echo "Updating $mf..."
+    $echo "# If this runs make out of memory, delete /usr/include lines." \
+	>> $mf.new
+    $sed 's|^\(.*\$(OBJ_EXT):\) *\(.*/.*\.c\) *$|\1 \2; '"$defrule \2|" .deptmp \
+       >>$mf.new
+else
+    $MAKE hlist || ($echo "Searching for .h files..."; \
+	$echo *.h | $tr ' ' $trnl | $egrep -v '\*' >.hlist)
+    $echo "You don't seem to have a proper C preprocessor.  Using grep instead."
+    $egrep '^#include ' `cat .clist` `cat .hlist`  >.deptmp
+    $echo "Updating $mf..."
+    <.clist $sed -n							\
+	-e '/\//{'							\
+	-e   's|^\(.*\)/\(.*\)\.c|\2\$(OBJ_EXT): \1/\2.c; '"$defrule \1/\2.c|p"	\
+	-e   d								\
+	-e '}'								\
+	-e 's|^\(.*\)\.c|\1\$(OBJ_EXT): \1.c|p' >> $mf.new
+    <.hlist $sed -n 's|\(.*/\)\(.*\)|s= \2= \1\2=|p' >.hsed
+    <.deptmp $sed -n 's|c:#include "\(.*\)".*$|o: \1|p' | \
+       $sed 's|^[^;]*/||' | \
+       $sed -f .hsed >> $mf.new
+    <.deptmp $sed -n 's|h:#include "\(.*\)".*$|h: \1|p' | \
+       $sed -f .hsed >> $mf.new
+    for file in `$cat .shlist`; do
+	$echo `$expr X$file : 'X\(.*\).SH'`: $file $TOP/config.sh \; \
+	    $sh $file >> $mf.new
+    done
+fi
+$rm -f $mf.old
+$cp $mf $mf.old
+$rm -f $mf
+$cp $mf.new $mf
+$rm $mf.new
+$echo "# WARNING: Put nothing here or make depend will gobble it up!" >> $mf
+$rm -rf .deptmp UU .shlist .clist .hlist .hsed .cout .cerr
+rmdir .depending
+
+!NO!SUBS!
+$eunicefix makedepend
+chmod +x makedepend
+case `pwd` in
+*SH)
+    $rm -f ../makedepend
+    ln makedepend ../makedepend
+    ;;
+esac

--- a/src/arm-ubuntu-spec-2006/files/md5sum.c
+++ b/src/arm-ubuntu-spec-2006/files/md5sum.c
@@ -1,0 +1,774 @@
+/* Compute MD5 checksum of files or strings according to the definition
+   of MD5 in RFC 1321 from April 1992.
+   Copyright (C) 95, 1996 Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+/* Written by Ulrich Drepper <drepper@gnu.ai.mit.edu>.  */
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <getopt.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+#ifdef HAVE_STDLIB_H
+# include <stdlib.h>
+#endif
+
+/* Unconditional for now, since it's POSIX. */
+#include <dirent.h>
+
+#include "long-options.h"
+#include "md5.h"
+// #include "getline.h"
+#include "system.h"
+#include "error.h"
+#include "xmalloc.h"
+
+#ifndef PATH_MAX
+# define PATH_MAX 1024
+#endif
+
+#if defined(_WIN32)
+# define MYSTAT _stat
+# ifndef S_ISDIR
+#  define S_ISDIR(x) (((x) & _S_IFDIR) != 0)
+# endif
+# define STRDUP _strdup
+#else
+# define MYSTAT stat
+# define STRDUP strdup
+#endif
+
+/* Most systems do not distinguish between external and internal
+   text representations.  */
+#if UNIX || __UNIX__ || unix || __unix__ || _POSIX_VERSION
+# define OPENOPTS(BINARY) "r"
+#else
+# ifdef MSDOS
+#  define TEXT1TO1 "rb"
+#  define TEXTCNVT "r"
+# else
+#  if defined VMS
+#   define TEXT1TO1 "rb", "ctx=stm"
+#   define TEXTCNVT "r", "ctx=stm"
+#  else
+    /* The following line is intended to evoke an error.
+       Using #error is not portable enough.  */
+    "Cannot determine system type."
+#  endif
+# endif
+# define OPENOPTS(BINARY) ((BINARY) != 0 ? TEXT1TO1 : TEXTCNVT)
+#endif
+
+#if _LIBC || STDC_HEADERS
+# define TOLOWER(c) tolower (c)
+#else
+# define TOLOWER(c) (ISUPPER (c) ? tolower (c) : (c))
+#endif
+
+/* The minimum length of a valid digest line in a file produced
+   by `md5sum FILE' and read by `md5sum --check'.  This length does
+   not include any newline character at the end of a line.  */
+#define MIN_DIGEST_LINE_LENGTH (32 /* message digest length */ \
+				+ 2 /* blank and binary indicator */ \
+				+ 3 /* blank and size and blank */ \
+				+ 1 /* minimum filename length */ )
+
+/* Nonzero if any of the files read were the standard input. */
+static int have_read_stdin;
+
+/* With --check, don't generate any output.
+   The exit code indicates success or failure.  */
+static int status_only = 0;
+
+/* With --check, print a message to standard error warning about each
+   improperly formatted MD5 checksum line.  */
+static int warn = 0;
+
+/* Whether to expect or output "normal" format files */
+static int normal_lines = 1;
+
+/* The name this program was run with.  */
+char *program_name;
+
+static const struct option long_options[] =
+{
+  { "binary", no_argument, 0, 'b' },
+  { "check", no_argument, 0, 'c' },
+  { "status", no_argument, 0, 2 },
+  { "string", required_argument, 0, 1 },
+  { "text", no_argument, 0, 't' },
+  { "warn", no_argument, 0, 'w' },
+  { "extended", no_argument, 0, 'n' },
+  { NULL, 0, NULL, 0 }
+};
+
+static void read_tree(const char *path, int *endpos, int *new_end, char ***files);
+
+static void
+usage (int status)
+{
+  if (status != 0)
+    fprintf (stderr, _("Try `%s --help' for more information.\n"),
+	     program_name);
+  else
+    {
+      printf (_("\
+Usage: %s [OPTION] [FILE]...\n\
+  or:  %s [OPTION] --check [FILE]\n\
+Print or check MD5 checksums.\n\
+With no FILE, or when FILE is -, read standard input.\n\
+\n\
+  -b, --binary            read files in binary mode\n\
+  -c, --check             check MD5 sums against given list\n\
+  -t, --text              read files in text mode (default)\n\
+  -e, --extended          read or write checksum files with embedded sizes\n\
+\n\
+The following two options are useful only when verifying checksums:\n\
+      --status            don't output anything, status code shows success\n\
+  -w, --warn              warn about improperly formated MD5 checksum lines\n\
+\n\
+      --help              display this help and exit\n\
+      --version           output version information and exit\n\
+\n\
+The sums are computed as described in RFC 1321.  When checking, the input\n\
+should be a former output of this program.  The default mode is to print\n\
+a line with checksum, a character indicating type (`*' for binary, ` ' for\n\
+text), and name for each FILE.\n"),
+	      program_name, program_name, program_name);
+      puts (_("\nReport bugs to textutils-bugs@gnu.ai.mit.edu"));
+    }
+
+  exit (status == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+static int
+split_3 (char *s, size_t s_len, char **u, int *binary, size_t *size, char **w)
+{
+  size_t i;
+  int filename_has_newline = 0;
+  char *endptr;
+
+#define ISWHITE(c) ((c) == ' ' || (c) == '\t')
+
+  i = 0;
+  while (ISWHITE (s[i]))
+    ++i;
+
+  /* The line must have at least 35 (36 if the first is a backslash)
+     more characters to contain correct message digest information.
+     Ignore this line if it is too short.  */
+  if (!(s_len - i >= MIN_DIGEST_LINE_LENGTH + (-normal_lines * 3)
+	|| (s[i] == '\\' && s_len - i >= 1 + MIN_DIGEST_LINE_LENGTH + (-normal_lines * 3))))
+    return 1;
+
+  if (s[i] == '\\')
+    {
+      ++i;
+      filename_has_newline = 1;
+    }
+  *u = &s[i];
+
+  /* The first field has to be the 32-character hexadecimal
+     representation of the message digest.  If it is not followed
+     immediately by a white space it's an error.  */
+  i += 32;
+  if (!ISWHITE (s[i]))
+    return 1;
+
+  s[i++] = '\0';
+
+  if (s[i] != ' ' && s[i] != '*')
+    return 1;
+ /* For the purposes of SPEC CPU, _all_ files are binary. */
+  *binary = (s[i++] == '*') || 1;
+
+  if (!normal_lines) {
+    /* Process the size field */
+    if (!ISWHITE(s[i++]))
+      return 1;
+    *size = (size_t)strtoull(s+i, &endptr, 16);
+    if (endptr)
+      i = endptr - s;
+    if (!ISWHITE(s[i++]))
+      return 1;
+  }
+
+  /* All characters between the type indicator and end of line are
+     significant -- that includes leading and trailing white space.  */
+  *w = &s[i];
+
+  if (filename_has_newline)
+    {
+      /* Translate each `\n' string in the file name to a NEWLINE,
+	 and each `\\' string to a backslash.  */
+
+      char *dst = &s[i];
+
+      while (i < s_len)
+	{
+	  switch (s[i])
+	    {
+	    case '\\':
+	      if (i == s_len - 1)
+		{
+		  /* A valid line does not end with a backslash.  */
+		  return 1;
+		}
+	      ++i;
+	      switch (s[i++])
+		{
+		case 'n':
+		  *dst++ = '\n';
+		  break;
+		case '\\':
+		  *dst++ = '\\';
+		  break;
+		default:
+		  /* Only `\' or `n' may follow a backslash.  */
+		  return 1;
+		}
+	      break;
+
+	    case '\0':
+	      /* The file name may not contain a NUL.  */
+	      return 1;
+	      break;
+
+	    default:
+	      *dst++ = s[i++];
+	      break;
+	    }
+	}
+      *dst = '\0';
+    }
+  return 0;
+}
+
+static int
+hex_digits (const char *s)
+{
+  while (*s)
+    {
+      if (!ISXDIGIT (*s))
+        return 0;
+      ++s;
+    }
+  return 1;
+}
+
+/* An interface to md5_stream.  Operate on FILENAME (it may be "-") and
+   put the result in *MD5_RESULT.  Return non-zero upon failure, zero
+   to indicate success.  */
+
+static int
+md5_file (const char *filename, int binary, size_t *size, unsigned char *md5_result)
+{
+  FILE *fp;
+  int err;
+
+  if (strcmp (filename, "-") == 0)
+    {
+      have_read_stdin = 1;
+      fp = stdin;
+    }
+  else
+    {
+      /* OPENOPTS is a macro.  It varies with the system.
+	 Some systems distinguish between internal and
+	 external text representations.  */
+
+      fp = fopen (filename, OPENOPTS (binary));
+      if (fp == NULL)
+	{
+	  error (0, errno, "%s", filename);
+	  return 1;
+	}
+    }
+
+  err = md5_stream (fp, size, md5_result);
+  if (err)
+    {
+      error (0, errno, "%s", filename);
+      if (fp != stdin)
+	fclose (fp);
+      return 1;
+    }
+
+  if (fp != stdin && fclose (fp) == EOF)
+    {
+      error (0, errno, "%s", filename);
+      return 1;
+    }
+
+  return 0;
+}
+
+static int
+md5_check (const char *checkfile_name)
+{
+  FILE *checkfile_stream;
+  int n_properly_formated_lines = 0;
+  int n_mismatched_checksums = 0;
+  int n_open_or_read_failures = 0;
+  int n_size_mismatches = 0;
+  unsigned char md5buffer[16];
+  size_t line_number;
+  char *line;
+  size_t line_chars_allocated;
+  size_t size;
+
+  if (strcmp (checkfile_name, "-") == 0)
+    {
+      have_read_stdin = 1;
+      checkfile_name = _("standard input");
+      checkfile_stream = stdin;
+    }
+  else
+    {
+      checkfile_stream = fopen (checkfile_name, "r");
+      if (checkfile_stream == NULL)
+	{
+	  error (0, errno, "%s", checkfile_name);
+	  return 1;
+	}
+    }
+
+  line_number = 0;
+  line = NULL;
+  line_chars_allocated = 0;
+  do
+    {
+      char *filename;
+      int binary;
+      char *md5num;
+      int err;
+      int line_length;
+      size_t file_len = 0;
+
+      ++line_number;
+
+      line_length = getline (&line, &line_chars_allocated, checkfile_stream);
+      if (line_length <= 0)
+	break;
+
+      /* Ignore comment lines, which begin with a '#' character.  */
+      if (line[0] == '#')
+	continue;
+
+      /* Remove any trailing EOLs.  */
+      while (line[line_length - 1] == '\n' || line[line_length - 1] == '\r')
+	line[--line_length] = '\0';
+
+      err = split_3 (line, line_length, &md5num, &binary, &size, &filename);
+      if (err || !hex_digits (md5num))
+	{
+	  if (warn)
+	    {
+	      error (0, 0,
+		     _("%s: %lu: improperly formatted MD5 checksum line"),
+		     checkfile_name, (unsigned long) line_number);
+	    }
+	}
+      else
+	{
+	  static const char bin2hex[] = { '0', '1', '2', '3',
+					  '4', '5', '6', '7',
+					  '8', '9', 'a', 'b',
+					  'c', 'd', 'e', 'f' };
+	  int fail;
+
+	  ++n_properly_formated_lines;
+
+	  fail = md5_file (filename, binary, &file_len, md5buffer);
+
+	  if (fail || (!normal_lines && file_len != size))
+	    {
+	      if (fail) {
+		++n_open_or_read_failures;
+		if (!status_only)
+		  {
+		    printf (_("%s: FAILED open or read\n"), filename);
+		    fflush (stdout);
+		  }
+	      } else {
+		++n_size_mismatches;
+		if (!status_only)
+		  {
+		    printf (_("%s: FAILED size mismatch\n"), filename);
+		    fflush (stdout);
+		  }
+	      }
+	    }
+	  else
+	    {
+	      size_t cnt;
+	      /* Compare generated binary number with text representation
+		 in check file.  Ignore case of hex digits.  */
+	      for (cnt = 0; cnt < 16; ++cnt)
+		{
+		  if (TOLOWER (md5num[2 * cnt]) != bin2hex[md5buffer[cnt] >> 4]
+		      || (TOLOWER (md5num[2 * cnt + 1])
+			  != (bin2hex[md5buffer[cnt] & 0xf])))
+		    break;
+		}
+	      if (cnt != 16)
+		++n_mismatched_checksums;
+
+	      if (!status_only)
+		{
+		  printf ("%s: %s\n", filename,
+			  (cnt != 16 ? _("FAILED") : _("OK")));
+		  fflush (stdout);
+		}
+	    }
+	}
+    }
+  while (!feof (checkfile_stream) && !ferror (checkfile_stream));
+
+  if (line)
+    free (line);
+
+  if (ferror (checkfile_stream))
+    {
+      error (0, 0, _("%s: read error"), checkfile_name);
+      return 1;
+    }
+
+  if (checkfile_stream != stdin && fclose (checkfile_stream) == EOF)
+    {
+      error (0, errno, "%s", checkfile_name);
+      return 1;
+    }
+
+  if (n_properly_formated_lines == 0)
+    {
+      /* Warn if no tests are found.  */
+      error (0, 0, _("%s: no properly formatted MD5 checksum lines found"),
+	     checkfile_name);
+    }
+  else
+    {
+      if (!status_only)
+	{
+	  int n_computed_checkums = (n_properly_formated_lines
+				     - n_open_or_read_failures);
+
+	  if (n_open_or_read_failures > 0)
+	    {
+	      error (0, 0,
+		   _("WARNING: %d of %d listed %s could not be read\n"),
+		     n_open_or_read_failures, n_properly_formated_lines,
+		     (n_properly_formated_lines == 1
+		      ? _("file") : _("files")));
+	    }
+
+	  if (n_mismatched_checksums > 0)
+	    {
+	      error (0, 0,
+		   _("WARNING: %d of %d computed %s did NOT match"),
+		     n_mismatched_checksums, n_computed_checkums,
+		     (n_computed_checkums == 1
+		      ? _("checksum") : _("checksums")));
+	    }
+
+	  if (n_size_mismatches > 0)
+	    {
+	      error (0, 0,
+		   _("WARNING: %d of %d file %s did NOT match"),
+		     n_size_mismatches, n_properly_formated_lines,
+		     (n_properly_formated_lines == 1
+		      ? _("size") : _("sizes")));
+	    }
+	}
+    }
+
+  return ((n_properly_formated_lines > 0 && n_mismatched_checksums == 0
+	   && n_size_mismatches == 0 && n_open_or_read_failures == 0) ? 0 : 1);
+}
+
+int
+main (int argc, char **argv)
+{
+  unsigned char md5buffer[16];
+  int do_check = 0;
+  int opt;
+  char **string = NULL;
+  size_t n_strings = 0;
+  size_t i;
+  size_t err = 0;
+  int file_type_specified = 0;
+  int end, space;
+  char **files;
+
+
+  /* Text is default of the Plumb/Lankester format.  */
+  /* We like binary better anyway. */
+  int binary = 1;
+
+  /* Setting values of global variables.  */
+  program_name = argv[0];
+  setlocale (LC_ALL, "");
+  bindtextdomain (PACKAGE, LOCALEDIR);
+  textdomain (PACKAGE);
+
+  parse_long_options (argc, argv, "md5sum", GNU_PACKAGE, VERSION, usage);
+
+  while ((opt = getopt_long (argc, argv, "bctwe", long_options, NULL))
+	 != EOF)
+    switch (opt)
+      {
+      case 0:			/* long option */
+	break;
+      case 1: /* --string */
+	{
+	  if (string == NULL)
+	    string = (char **) xmalloc ((argc - 1) * sizeof (char *));
+
+	  if (optarg == NULL)
+	    optarg = "";
+	  string[n_strings++] = optarg;
+	}
+	break;
+      case 'b': /* --binary */
+	file_type_specified = 1;
+	binary = 1;
+	break;
+      case 'c':
+	do_check = 1;
+	break;
+      case 2:
+	status_only = 1;
+	warn = 0;
+	break;
+      case 't': /* --text */
+	file_type_specified = 1;
+	binary = 0;
+	break;
+      case 'w':
+	status_only = 0;
+	warn = 1;
+	break;
+      case 'e':
+	normal_lines = 0;
+	break;
+      default:
+	usage (EXIT_FAILURE);
+      }
+
+  if (file_type_specified && do_check)
+    {
+      error (0, 0, _("the --binary and --text options are meaningless when \
+verifying checksums"));
+      usage (EXIT_FAILURE);
+    }
+
+  if (n_strings > 0 && do_check)
+    {
+      error (0, 0,
+	     _("the --string and --check options are mutually exclusive"));
+      usage (EXIT_FAILURE);
+    }
+
+  if (status_only && !do_check)
+    {
+      error (0, 0,
+       _("the --status option is meaningful only when verifying checksums"));
+      usage (EXIT_FAILURE);
+    }
+
+  if (warn && !do_check)
+    {
+      error (0, 0,
+       _("the --warn option is meaningful only when verifying checksums"));
+      usage (EXIT_FAILURE);
+    }
+
+  if (n_strings > 0)
+    {
+      if (optind < argc)
+	{
+	  error (0, 0, _("no files may be specified when using --string"));
+	  usage (EXIT_FAILURE);
+	}
+      for (i = 0; i < n_strings; ++i)
+	{
+	  size_t cnt;
+	  md5_buffer (string[i], strlen (string[i]), md5buffer);
+
+	  for (cnt = 0; cnt < 16; ++cnt)
+	    printf ("%02x", md5buffer[cnt]);
+
+	  printf ("  \"%s\"\n", string[i]);
+	}
+    }
+  else if (do_check)
+    {
+      if (optind + 1 < argc)
+	{
+	  error (0, 0,
+		 _("only one argument may be specified when using --check"));
+	  usage (EXIT_FAILURE);
+	}
+
+      err = md5_check ((optind == argc) ? "-" : argv[optind]);
+    }
+  else
+    {
+      if (optind == argc)
+	argv[argc++] = "-";
+
+      /* Copy argc and argv into something that can be modified */
+      end = space = argc - optind;
+      files = (char **)malloc(sizeof(char *) * end);
+      for (i = 0; i < end; i++) {
+	files[i] = STRDUP(argv[optind + i]);
+      }
+
+      for (i = 0; i < end; i++)
+	{
+	  int fail;
+	  char *file = files[i];
+	  size_t size = 0;
+	  struct MYSTAT statbuf;
+
+	  fail = MYSTAT(file, &statbuf);
+	  if (fail != 0 && strcmp(file, "-")) {
+	    error(EXIT_FAILURE, errno, "stat %s", file);
+	  }
+	  if (S_ISDIR(statbuf.st_mode)) {
+	    read_tree(file, &end, &space, &files);
+	    continue;
+	  }
+
+	  fail = md5_file (file, binary, &size, md5buffer);
+	  err |= fail;
+	  if (!fail)
+	    {
+	      size_t i;
+
+	      /* Output a leading backslash if the file name contains
+		 a newline.  */
+	      if (strchr (file, '\n'))
+		putchar ('\\');
+
+	      for (i = 0; i < 16; ++i)
+		printf ("%02x", md5buffer[i]);
+
+	      putchar (' ');
+	      if (binary)
+		putchar ('*');
+	      else
+		putchar (' ');
+
+	      if (!normal_lines) {
+		putchar (' ');
+		printf ("%08X", size);
+		putchar (' ');
+	      }
+
+	      /* Translate each NEWLINE byte to the string, "\\n",
+		 and each backslash to "\\\\".  */
+	      for (i = 0; i < strlen (file); ++i)
+		{
+		  switch (file[i])
+		    {
+		    case '\n':
+		      fputs ("\\n", stdout);
+		      break;
+
+		    case '\\':
+		      fputs ("\\\\", stdout);
+		      break;
+
+		    default:
+		      putchar (file[i]);
+		      break;
+		    }
+		}
+	      putchar ('\n');
+	    }
+	}
+    }
+
+  if (fclose (stdout) == EOF)
+    error (EXIT_FAILURE, errno, _("write error"));
+
+  if (have_read_stdin && fclose (stdin) == EOF)
+    error (EXIT_FAILURE, errno, _("standard input"));
+
+  exit (err == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+/* Expand the directory tree under path, appending the path list to files. */
+static void read_tree(const char *path, int *endpos, int *new_end, char ***files) {
+  DIR *dirptr;
+  struct dirent *ent;
+  struct MYSTAT st;
+  int rc = 0;
+  char pathbuf[PATH_MAX];
+  char *fnstart;
+  static int depth = 0;
+
+  depth++;
+
+  dirptr = opendir(path);
+  if (dirptr == NULL) {
+    error(EXIT_FAILURE, errno, "opendir(%s)", path);
+  }
+
+
+  errno = 0;
+  strcpy(pathbuf, path);
+  strcat(pathbuf, "/");
+  fnstart = pathbuf + strlen(path) + 1;
+  
+  while((ent = readdir(dirptr)) != NULL) {
+    if (strcmp(ent->d_name, ".\0") && strcmp(ent->d_name, "..\0")) {
+      strcpy(fnstart, ent->d_name);
+
+      rc = MYSTAT(pathbuf, &st);
+      if (rc != 0) {
+	error(EXIT_FAILURE, errno, "stat of %s", pathbuf);
+      }
+      if (S_ISDIR(st.st_mode)) {
+	read_tree(pathbuf, endpos, new_end, files);
+      } else {
+	if (*endpos >= *new_end) {
+	  /* Since pointers are small, add room for another 256 entries */
+	  *files = xrealloc(*files, sizeof(char **) * (*endpos + 256));
+	  *new_end = *endpos + 256;
+	}
+	(*files)[*endpos] = STRDUP(pathbuf);
+	if ((*files)[*endpos] != NULL) {
+	  (*endpos)++;
+	} else {
+	  error(EXIT_FAILURE, errno, "read_tree: error allocating memory");
+	}
+      }
+    }
+    errno = 0; /* To be able to detect errors from readdir() */
+  }
+  if (ent == NULL && errno != 0) {
+    error(EXIT_FAILURE, errno, "readdir");
+  } else {
+    closedir(dirptr);
+  }
+  depth--;
+}

--- a/src/arm-ubuntu-spec-2006/files/replace-configs.sh
+++ b/src/arm-ubuntu-spec-2006/files/replace-configs.sh
@@ -1,0 +1,10 @@
+# fixes the first error in Zhantong's errors file
+
+for dir in /home/gem5/spec2006/tools/src/expat-1.95.8/conftools /home/gem5/spec2006/tools/src/tar-1.15.1/config /home/gem5/spec2006/tools/src/specinvoke /home/gem5/spec2006/tools/src/make-3.80/config; do
+
+cd $dir
+echo "12345" | sudo rm config.guess config.sub
+wget -O config.guess 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD'
+wget -O config.sub 'https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD'
+
+done

--- a/src/arm-ubuntu-spec-2006/files/serial-getty@.service
+++ b/src/arm-ubuntu-spec-2006/files/serial-getty@.service
@@ -1,0 +1,46 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Serial Getty on %I
+Documentation=man:agetty(8) man:systemd-getty-generator(8)
+Documentation=http://0pointer.de/blog/projects/serial-console.html
+BindsTo=dev-%i.device
+After=dev-%i.device systemd-user-sessions.service plymouth-quit-wait.service getty-pre.target
+After=rc-local.service
+
+# If additional gettys are spawned during boot then we should make
+# sure that this is synchronized before getty.target, even though
+# getty.target didn't actually pull it in.
+Before=getty.target
+IgnoreOnIsolate=yes
+
+# IgnoreOnIsolate causes issues with sulogin, if someone isolates
+# rescue.target or starts rescue.service from multi-user.target or
+# graphical.target.
+Conflicts=rescue.service
+Before=rescue.service
+
+[Service]
+# The '-o' option value tells agetty to replace 'login' arguments with an
+# option to preserve environment (-p), followed by '--' for safety, and then
+# the entered username.
+ExecStart=-/sbin/agetty --autologin gem5 --keep-baud 115200,38400,9600 %I $TERM
+Type=idle
+Restart=always
+UtmpIdentifier=%I
+TTYPath=/dev/%I
+TTYReset=yes
+TTYVHangup=yes
+KillMode=process
+IgnoreSIGPIPE=no
+SendSIGHUP=yes
+
+[Install]
+WantedBy=getty.target

--- a/src/arm-ubuntu-spec-2006/http-24-04/user-data
+++ b/src/arm-ubuntu-spec-2006/http-24-04/user-data
@@ -1,0 +1,87 @@
+
+#cloud-config
+autoinstall:
+  apt:
+    disable_components: []
+    geoip: true
+    preserve_sources_list: false
+    primary:
+    - arches:
+      - amd64
+      - i386
+      uri: http://archive.ubuntu.com/ubuntu
+    - arches:
+      - default
+      uri: http://us.ports.ubuntu.com/ubuntu-ports
+
+  drivers:
+    install: false
+  identity:
+    hostname: gem5
+    password: $6$TBZcqP/4zmP6cvBx$x4MAAfPL25/QAI6tRGfzJJG1.wcvTew15FVIZc3ys4jvbRiI/8eBBd9HLUm0HJAXNFsBDCdBBM0gZ4vauiH5s.
+    realname: gem5
+    username: gem5
+  kernel:
+    package: linux-generic
+  keyboard:
+    layout: us
+    toggle: null
+    variant: ''
+  locale: en_US.UTF-8
+  network:
+    ethernets:
+      enp0s3:
+        dhcp4: true
+    version: 2
+  ssh:
+    allow-pw: true
+    authorized-keys: []
+    install-server: true
+  storage:
+    config:
+    - ptable: gpt
+      path: /dev/vda
+      wipe: superblock-recursive
+      preserve: false
+      name: ''
+      grub_device: false
+      type: disk
+      id: disk-vda
+    - device: disk-vda
+      size: 564133888
+      wipe: superblock
+      flag: boot
+      number: 1
+      preserve: false
+      grub_device: true
+      type: partition
+      id: partition-0
+    - fstype: fat32
+      volume: partition-0
+      preserve: false
+      type: format
+      id: format-0
+    - device: disk-vda
+      size: 12771655680
+      wipe: superblock
+      flag: ''
+      number: 2
+      preserve: false
+      grub_device: false
+      type: partition
+      id: partition-1
+    - fstype: ext4
+      volume: partition-1
+      preserve: false
+      type: format
+      id: format-1
+    - path: /
+      device: format-1
+      type: mount
+      id: mount-1
+    - path: /boot/efi
+      device: format-0
+      type: mount
+      id: mount-0
+  updates: security
+  version: 1

--- a/src/arm-ubuntu-spec-2006/make-flash0.sh
+++ b/src/arm-ubuntu-spec-2006/make-flash0.sh
@@ -1,0 +1,3 @@
+cd files
+dd if=/dev/zero of=flash0.img bs=1M count=64
+dd if=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd of=flash0.img conv=notrunc

--- a/src/arm-ubuntu-spec-2006/scripts/install-spec2006.sh
+++ b/src/arm-ubuntu-spec-2006/scripts/install-spec2006.sh
@@ -1,0 +1,55 @@
+# Copyright (c) 2020 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+# install build-essential (gcc and g++ included) and gfortran
+echo "12345" | sudo apt-get install build-essential gfortran
+
+# mount the SPEC2006 ISO file and install SPEC to the disk image
+mkdir /home/gem5/mnt
+
+mkdir /home/gem5/spec2006
+
+echo "12345" | sudo mount -o loop -t iso9660 /home/gem5/CPU2006v1.0.1.iso /home/gem5/mnt
+
+cd /home/gem5/mnt
+cp -r * /home/gem5/spec2006
+
+# Modifications to certain files are needed to get SPEC2006 to install. 
+# The following commands put the pre-modified files in the right place.
+
+echo "12345" | sudo mv /home/gem5/glob.c /home/gem5/spec2006/tools/src/make-3.80/glob/glob.c
+
+echo "12345" | sudo mv /home/gem5/md5sum.c /home/gem5/spec2006/tools/src/specmd5sum/md5sum.c
+
+echo "12345" | sudo mv /home/gem5/SysV.xs /home/gem5/spec2006/tools/src/perl-5.8.7/ext/IPC/SysV/SysV.xs
+
+echo "12345" | sudo mv /home/gem5/makedepend.SH /home/gem5/spec2006/tools/src/perl-5.8.7/makedepend.SH
+
+cd /home/gem5
+
+./replace-configs.sh
+
+sudo rm /bin/sh
+sudo ln -s /bin/bash /bin/sh
+
+
+# Install SPEC 2006
+
+cd /home/gem5/spec2006/tools/src
+
+PERLFLAGS="-A libs=-lm -A libs=-ldl" ./buildtools
+cd /home/gem5/spec2006
+. /home/gem5/spec2006/shrc
+umount /home/gem5/mnt
+rm -f /home/CPU2006v1.0.1.iso
+
+# use the gcc42 config as the template
+cp /home/gem5/spec2006/config/linux64-amd64-gcc42.cfg /home/gem5/spec2006/config/myconfig.cfg
+
+# Those 'sed' commands replace paths to gcc, g++ and gfortran binary from /usr/local/sles9/gcc42-0325/bin/* to /usr/bin/*
+sed -i "s/\/usr\/local\/sles9\/gcc42-0325\/bin\/gcc/\/usr\/bin\/gcc/g" /home/gem5/spec2006/config/myconfig.cfg
+sed -i "s/\/usr\/local\/sles9\/gcc42-0325\/bin\/g++/\/usr\/bin\/g++/g" /home/gem5/spec2006/config/myconfig.cfg
+sed -i "s/\/usr\/local\/sles9\/gcc42-0325\/bin\/gfortran/\/usr\/bin\/gfortran/g" /home/gem5/spec2006/config/myconfig.cfg
+
+# build all SPEC workloads
+runspec --config=myconfig.cfg --action=build all

--- a/src/arm-ubuntu-spec-2006/scripts/install-spec2017.sh
+++ b/src/arm-ubuntu-spec-2006/scripts/install-spec2017.sh
@@ -1,0 +1,39 @@
+# Copyright (c) 2020 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+# install build-essential (gcc and g++ included) and gfortran
+echo "12345" | sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential gfortran
+
+# mount the SPEC2017 ISO file and install SPEC to the disk image
+mkdir /home/gem5/mnt
+mount -o loop -t iso9660 /home/gem5/cpu2017-1.1.0.iso /home/gem5/mnt
+mkdir /home/gem5/spec2017
+echo "y" | /home/gem5/mnt/install.sh -d /home/gem5/spec2017 -u linux-x86_64
+cd /home/gem5/spec2017
+. /home/gem5/mnt/shrc
+umount /home/gem5/mnt
+rm -f /home/gem5/cpu2017-1.1.0.iso
+
+# use the example config as the template
+cp /home/gem5/spec2017/config/Example-gcc-linux-x86.cfg /home/gem5/spec2017/config/myconfig.x86.cfg
+
+# use sed command to remove the march=native flag when compiling
+# this is necessary as the packer script runs in kvm mode, so the details of the CPU will be that of the host CPU
+# the -march=native flag is removed to avoid compiling instructions that gem5 does not support
+# finetuning flags should be manually added
+sed -i "s/-march=native//g" /home/gem5/spec2017/config/myconfig.x86.cfg
+
+# prevent runcpu from calling sysinfo
+# https://www.spec.org/cpu2017/Docs/config.html#sysinfo-program
+# this is necessary as the sysinfo program queries the details of the system's CPU
+# the query causes gem5 runtime error
+sed -i "s/command_add_redirect = 1/sysinfo_program =\ncommand_add_redirect = 1/g" /home/gem5/spec2017/config/myconfig.x86.cfg
+
+# build all SPEC workloads
+# build_ncpus: number of cpus to build the workloads
+# gcc_dir: where to find the compilers (gcc, g++, gfortran)
+runcpu --config=myconfig.x86.cfg --define build_ncpus=$(nproc) --define gcc_dir="/usr" --action=build all
+
+# the above building process will produce a large log file
+# this command removes the log files to avoid copying out large files unnecessarily
+rm -f /home/gem5/spec2017/result/*

--- a/src/arm-ubuntu-spec-2006/scripts/post-installation.sh
+++ b/src/arm-ubuntu-spec-2006/scripts/post-installation.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Copyright (c) 2024 The Regents of the University of California.
+# SPDX-License-Identifier: BSD 3-Clause
+
+echo 'Post Installation Started'
+
+echo 'installing packages'
+apt-get update
+apt-get install -y scons
+apt-get install -y git
+apt-get install -y vim
+apt-get install -y build-essential
+
+echo "Installing serial service for autologin after systemd"
+mv /home/gem5/serial-getty@.service /lib/systemd/system/
+
+echo "Installing the gem5 init script in /sbin"
+mv /home/gem5/gem5_init.sh /sbin
+mv /sbin/init /sbin/init.old
+ln -s /sbin/gem5_init.sh /sbin/init
+
+# Add after_boot.sh to bashrc in the gem5 user account
+# This will run the script after the user automatically logs in
+echo -e "\nif [ -z \"\$AFTER_BOOT_EXECUTED\" ]; then\n   export AFTER_BOOT_EXECUTED=1\n    /home/gem5/after_boot.sh\nfi\n" >> /home/gem5/.bashrc
+
+# Remove the motd
+rm /etc/update-motd.d/*
+
+# Build and install the gem5-bridge (m5) binary, library, and headers
+echo "Building and installing gem5-bridge (m5) and libm5"
+
+# Just get the files we need
+git clone https://github.com/gem5/gem5.git --depth=1 --filter=blob:none --no-checkout --sparse --single-branch --branch=stable
+pushd gem5
+# Checkout just the files we need
+git sparse-checkout add util/m5
+git sparse-checkout add include
+git checkout
+# Install the headers globally so that other benchmarks can use them
+cp -r include/gem5 /usr/local/include/\
+
+# Build the library and binary
+pushd util/m5
+scons build/arm64/out/m5
+cp build/arm64/out/m5 /usr/local/bin/
+cp build/arm64/out/libm5.a /usr/local/lib/
+popd
+popd
+
+# rename the m5 binary to gem5-bridge
+mv /usr/local/bin/m5 /usr/local/bin/gem5-bridge
+# Set the setuid bit on the m5 binary
+chmod 4755 /usr/local/bin/gem5-bridge
+chmod u+s /usr/local/bin/gem5-bridge
+
+#create a symbolic link to the gem5 binary for backward compatibility
+ln -s /usr/local/bin/gem5-bridge /usr/local/bin/m5
+
+# delete the git repo for gem5
+rm -rf gem5
+echo "Done building and installing gem5-bridge (m5) and libm5"
+
+# You can extend this script to install your own packages here.
+
+# Disable network by default
+echo "Disabling network by default"
+echo "See README.md for instructions on how to enable network"
+if [ -f /etc/netplan/50-cloud-init.yaml ]; then
+    mv /etc/netplan/50-cloud-init.yaml /etc/netplan/50-cloud-init.yaml.bak
+elif [ -f /etc/netplan/00-installer-config.yaml ]; then
+    mv /etc/netplan/00-installer-config.yaml /etc/netplan/00-installer-config.yaml.bak
+    netplan apply
+fi
+
+echo "Post Installation Done"


### PR DESCRIPTION
This adds files used to make an Arm Ubuntu 24.04 disk image with a working installation of SPEC 2006. Please note that the installation process modifies a number of files in the SPEC 2006 image based on the necessary changes listed here: https://github.com/studyztp/some-notes/blob/main/SPEC2006_RISCV_ubuntu20.04.4_issue_note.md

I still need to update the README.