### PR TITLE
Update links to iso for x86 and riscv images

### DIFF
--- a/src/riscv-fs/riscv-ubuntu-22.04-24.04/build.sh
+++ b/src/riscv-fs/riscv-ubuntu-22.04-24.04/build.sh
@@ -26,7 +26,7 @@ if [[ "$ubuntu_version" == "22.04" ]]; then
 fi
 
 if [[ "$ubuntu_version" == "24.04" ]]; then
-    wget https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64.img.xz
+    wget https://old-releases.ubuntu.com/releases/noble/ubuntu-24.04-preinstalled-server-riscv64.img.xz
     unxz ubuntu-24.04-preinstalled-server-riscv64.img.xz
 fi
 

--- a/src/ubuntu-generic-diskimages/packer-scripts/x86-ubuntu.pkr.hcl
+++ b/src/ubuntu-generic-diskimages/packer-scripts/x86-ubuntu.pkr.hcl
@@ -39,7 +39,7 @@ locals {
       output_dir    = "x86-disk-image-22-04"
     }
     "24.04" = {
-      iso_url       = "https://releases.ubuntu.com/releases/noble/ubuntu-24.04-live-server-amd64.iso"
+      iso_url       = "https://old-releases.ubuntu.com/releases/noble/ubuntu-24.04-live-server-amd64.iso"
       iso_checksum  = "sha256:8762f7e74e4d64d72fceb5f70682e6b069932deedb4949c6975d0f0fe0a91be3"
       output_dir    = "x86-disk-image-24-04"
     }


### PR DESCRIPTION
- Ubuntu updated the link on their website with the release of 24.04.01. So I am updating the iso links to point to old releases. The checksum of these new links are the same as the old ones