### PR TITLE
resources: add resource check to the building bash script

### DIFF
--- a/src/npb-24.04-imgs/build-arm.sh
+++ b/src/npb-24.04-imgs/build-arm.sh
@@ -13,10 +13,11 @@ dd if=/dev/zero of=flash0.img bs=1M count=64
 dd if=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd of=flash0.img conv=notrunc
 cd ..
 
-# get the  base image from gem5 resoruces
-wget https://storage.googleapis.com/dist.gem5.org/dist/develop/images/arm/ubuntu-24-04/arm-ubuntu-24.04-20240823.gz
-gunzip arm-ubuntu-24.04-20240823.gz 
-
+# get the  base image from gem5 resource
+if [! -f ./arm-ubuntu-24.04-20240823 ]; then
+    wget https://storage.googleapis.com/dist.gem5.org/dist/develop/images/arm/ubuntu-24-04/arm-ubuntu-24.04-20240823.gz
+    gunzip arm-ubuntu-24.04-20240823.gz 
+fi
 # Install the needed plugins
 ./packer init arm-npb.pkr.hcl
 

--- a/src/npb-24.04-imgs/build-x86.sh
+++ b/src/npb-24.04-imgs/build-x86.sh
@@ -11,9 +11,10 @@ if [ ! -f ./packer ]; then
     rm packer_${PACKER_VERSION}_linux_amd64.zip;
 fi
 
-wget https://storage.googleapis.com/dist.gem5.org/dist/develop/images/x86/ubuntu-24-04/x86-ubuntu-24-04-v2.gz
-gunzip x86-ubuntu-24-04-v2.gz
-
+if [! -f ./x86-ubuntu-24-04-v2 ]; then
+    wget https://storage.googleapis.com/dist.gem5.org/dist/develop/images/x86/ubuntu-24-04/x86-ubuntu-24-04-v2.gz
+    gunzip x86-ubuntu-24-04-v2.gz
+fi
 # Install the needed plugins
 ./packer init x86-npb.pkr.hcl
 


### PR DESCRIPTION
By adding the checks, we can avoid downloading the downloaded resources.  