### PR TITLE
[riscv-fs] fix stucking at bootup

### DIFF
--- a/src/riscv-fs/riscv-ubuntu-22.04-24.04/BUILING.md
+++ b/src/riscv-fs/riscv-ubuntu-22.04-24.04/BUILING.md
@@ -1,10 +1,10 @@
 ---
-title: Building the base x86-ubuntu image
+title: Building the base riscv-ubuntu image
 authors:
     - Harshil Patel
 ---
 
-This document provides instructions to create the "x86-ubuntu" image. This image is a 22.04 Ubuntu image.
+This document provides instructions to create the "riscv-ubuntu" image. This image is a 22.04 Ubuntu image.
 
 ## Directory map
 

--- a/src/riscv-fs/riscv-ubuntu-22.04-24.04/build.sh
+++ b/src/riscv-fs/riscv-ubuntu-22.04-24.04/build.sh
@@ -21,13 +21,17 @@ fi
 ubuntu_version="$1"
 
 if [[ "$ubuntu_version" == "22.04" ]]; then
-    wget https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz
-    unxz ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz
+    if [ ! -f ./ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img ]; then
+        wget https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz
+        unxz ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz
+    fi
 fi
 
 if [[ "$ubuntu_version" == "24.04" ]]; then
-    wget https://old-releases.ubuntu.com/releases/noble/ubuntu-24.04-preinstalled-server-riscv64.img.xz
-    unxz ubuntu-24.04-preinstalled-server-riscv64.img.xz
+    if [ ! -f ./ubuntu-24.04-preinstalled-server-riscv64.img ]; then
+        wget https://old-releases.ubuntu.com/releases/noble/ubuntu-24.04-preinstalled-server-riscv64.img.xz
+        unxz ubuntu-24.04-preinstalled-server-riscv64.img.xz
+    fi
 fi
 
 

--- a/src/riscv-fs/riscv-ubuntu-22.04-24.04/riscv-ubuntu.pkr.hcl
+++ b/src/riscv-fs/riscv-ubuntu-22.04-24.04/riscv-ubuntu.pkr.hcl
@@ -53,6 +53,7 @@ source "qemu" "initialize" {
   headless         = "true"
   disk_image       = "true"
   boot_command = [
+                  "<wait10><enter>",
                   "<wait120>",
                   "ubuntu<enter><wait>",
                   "ubuntu<enter><wait>",


### PR DESCRIPTION
I found that with the ubuntu-24.04 preinstalled image, it requires one more <enter> before the login prompt.
Also, we should not redownloaded the downloaded sources. The document shows that it is a x86 image while the document is for riscv.