### PR TITLE
resources: Update resources links point to azure storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ The compiled binary can be found in `src/gpu/square/bin`
 
 ### Square Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/square/square>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/square/square>
 
 # Resource: HIP Sample Applications
 
@@ -415,21 +415,21 @@ overridden by specifying `-e HCC_AMDGPU_TARGET=<target>` in the build command.
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/2dshfl>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/2dshfl>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/dynamic_shared>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/dynamic_shared>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/inline_asm>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/inline_asm>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/MatrixTranspose>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/MatrixTranspose>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/sharedMemory>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/sharedMemory>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/shfl>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/shfl>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/stream>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/stream>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/unroll>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/unroll>
 
 # Resource: Heterosync
 
@@ -452,7 +452,7 @@ that are currently unsupported in gem5.
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/heterosync/allSyncPrims-1kernel>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/heterosync/allSyncPrims-1kernel>
 
 # Resource: lulesh
 
@@ -491,7 +491,7 @@ docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu gem
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/lulesh/lulesh>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/lulesh/lulesh>
 
 # Resource: halo-finder (HACC)
 
@@ -538,7 +538,7 @@ docker run --rm -v $PWD:$PWD -w $PWD -u $UID:$GID <image_name> gem5/build/VEGA_X
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/halo-finder/ForceTreeTest>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/halo-finder/ForceTreeTest>
 
 # Resource: DNNMark
 
@@ -629,7 +629,7 @@ rounding.
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pennant/pennant>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pennant/pennant>
 
 ## Resource: SPEC 2006
 

--- a/src/gpu/halo-finder/README.md
+++ b/src/gpu/halo-finder/README.md
@@ -51,4 +51,4 @@ docker run --rm -v $PWD:$PWD -w $PWD -u $UID:$GID ghcr.io/gem5/gcn-gpu:v24-0 gem
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/halo-finder/ForceTreeTest>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/halo-finder/ForceTreeTest>

--- a/src/gpu/heterosync/README.md
+++ b/src/gpu/heterosync/README.md
@@ -38,7 +38,7 @@ docker run -u $UID:$GID --volume $(pwd):$(pwd) -w $(pwd) ghcr.io/gem5/gcn-gpu:v2
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/heterosync/allSyncPrims-1kernel>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/heterosync/allSyncPrims-1kernel>
 
 Information from original HeteroSync README included below:
 

--- a/src/gpu/hip-samples/README.md
+++ b/src/gpu/hip-samples/README.md
@@ -37,18 +37,18 @@ This can be changed by editing the --amdgpu-target argument in the Makefile.
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/2dshfl>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/2dshfl>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/dynamic_shared>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/dynamic_shared>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/inline_asm>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/inline_asm>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/MatrixTranspose>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/MatrixTranspose>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/sharedMemory>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/sharedMemory>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/shfl>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/shfl>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/stream>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/stream>
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/hip-samples/unroll>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/hip-samples/unroll>

--- a/src/gpu/lulesh/README.md
+++ b/src/gpu/lulesh/README.md
@@ -47,4 +47,4 @@ docker run --rm -v ${PWD}:${PWD} -w ${PWD} -u $UID:$GID ghcr.io/gem5/gcn-gpu:v24
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/lulesh/lulesh>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/lulesh/lulesh>

--- a/src/gpu/pannotia/bc/README.md
+++ b/src/gpu/pannotia/bc/README.md
@@ -56,4 +56,4 @@ We recommend you start with the 1k_128k.gr input (<http://dist.gem5.org/dist/dev
 ## Pre-built binary
 
 SE mode:
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/bc.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/bc.gem5>

--- a/src/gpu/pannotia/color/README.md
+++ b/src/gpu/pannotia/color/README.md
@@ -75,5 +75,5 @@ Note that 1k_128k is not designed for Color specifically though -- the above lin
 ## Pre-built binary
 
 SE mode:
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/color_max.gem5>
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/color_maxmin.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/color_max.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/color_maxmin.gem5>

--- a/src/gpu/pannotia/fw/README.md
+++ b/src/gpu/pannotia/fw/README.md
@@ -91,4 +91,4 @@ Note that 1k_128k is not designed for FW specifically though -- the above link h
 ## Pre-built binary
 
 SE mode:
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/fw_hip.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/fw_hip.gem5>

--- a/src/gpu/pannotia/mis/README.md
+++ b/src/gpu/pannotia/mis/README.md
@@ -69,4 +69,4 @@ Note that 1k_128k is not designed for MIS specifically though -- the above link 
 ## Pre-built binary
 
 SE mode:
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/mis_hip.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/mis_hip.gem5>

--- a/src/gpu/pannotia/pagerank/README.md
+++ b/src/gpu/pannotia/pagerank/README.md
@@ -75,5 +75,5 @@ We recommend you start with the coAuthorsDBLP input for PR.
 ## Pre-built binary
 
 SE mode:
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/pagerank.gem5>
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/pagerank_spmv.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/pagerank.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/pagerank_spmv.gem5>

--- a/src/gpu/pannotia/sssp/README.md
+++ b/src/gpu/pannotia/sssp/README.md
@@ -75,5 +75,5 @@ Note that 1k_128k is not designed for SSSP specifically though -- the above link
 ## Pre-built binary
 
 SE mode:
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/sssp.gem5>
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pannotia/sssp_ell.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/sssp.gem5>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pannotia/sssp_ell.gem5>

--- a/src/gpu/pennant/README.md
+++ b/src/gpu/pennant/README.md
@@ -40,7 +40,7 @@ compare against, and there may be slight differences due to floating-point round
 
 ## Pre-built binary
 
-<https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/pennant/pennant>
+<https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/pennant/pennant>
 
 The information from the original PENNANT README is included below.
 

--- a/src/gpu/square/README.md
+++ b/src/gpu/square/README.md
@@ -25,7 +25,7 @@ The compiled binary can be found in the `bin` directory.
 
 ## Pre-built binary
 
-A pre-built binary can be found at <https://storage.googleapis.com/dist.gem5.org/dist/v24-0/test-progs/square/square>
+A pre-built binary can be found at <https://gem5dist.blob.core.windows.net/dist/v24-0/test-progs/square/square>
 
 ## Compiling VEGA_X86/gem5.opt
 


### PR DESCRIPTION
- This PR updates the resource links that point to gcp to now point to the new azure storage.