### PR TITLE
resources: Bump GPU disk image kernel

### DIFF
--- a/src/x86-ubuntu-gpu-ml/scripts/rocm-install.sh
+++ b/src/x86-ubuntu-gpu-ml/scripts/rocm-install.sh
@@ -87,7 +87,7 @@ sudo chmod 777 /usr/lib/firmware/amdgpu/ip_discovery.bin
 
 # Install a known-working version of Linux as this might change after stable
 # release. Install this after DKMS so they are rebuilt.
-KERNEL=6.8.0-79-generic
+KERNEL=6.8.0-124-generic
 
 sudo apt -y install "linux-image-${KERNEL}"
 sudo apt -y install "linux-headers-${KERNEL}" "linux-modules-extra-${KERNEL}"


### PR DESCRIPTION
The GPU disk fixes a kernel version to ensure the same kernel is used when gem5 is released vs. in the future when a user might rebuild.

The kernel used in the stable GPU disk appears to have been obsoleted by Ubuntu and is no longer available. Therefore the current stable disk fails to build. Bump version to 6.8.0-124-generic from 6.8.0-79-generic. Re-ran local CI tests to confirm the new disk builds and can run applications.