### PR TITLE
resources: Add test for RISC-V Zacas extension

### DIFF
--- a/src/asmtest/isa/Makefile
+++ b/src/asmtest/isa/Makefile
@@ -58,10 +58,10 @@ vpath %.S $(src_dir)
 	$(RISCV_OBJDUMP) $< > $@
 
 %.out: %
-	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot_zicntr_zba_zbb_zbc_zbs --misaligned $< 2> $@
+	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot_zicntr_zacas_zba_zbb_zbc_zbs --misaligned $< 2> $@
 
 %.out32: %
-	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot_zicntr_zba_zbb_zbc_zbs --misaligned $< 2> $@
+	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot_zicntr_zacas_zba_zbb_zbc_zbs --misaligned $< 2> $@
 
 define compile_template
 

--- a/src/asmtest/isa/rv32ua/Makefrag
+++ b/src/asmtest/isa/rv32ua/Makefrag
@@ -3,8 +3,8 @@
 #-----------------------------------------------------------------------
 
 rv32ua_sc_tests = \
-	amoadd_w amoand_w amomax_w amomaxu_w amomin_w amominu_w amoor_w amoxor_w amoswap_w \
-	lrsc \
+	amoadd_w amoand_w amocas_w amomax_w amomaxu_w amomin_w amominu_w amoor_w amoxor_w amoswap_w \
+	amocas_d lrsc \
 
 rv32ua_p_tests = $(addprefix rv32ua-p-, $(rv32ua_sc_tests))
 rv32ua_v_tests = $(addprefix rv32ua-v-, $(rv32ua_sc_tests))

--- a/src/asmtest/isa/rv32ua/amocas_d.S
+++ b/src/asmtest/isa/rv32ua/amocas_d.S
@@ -1,0 +1,134 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# amocas_d.S
+#-----------------------------------------------------------------------------
+#
+# Test amocas.d instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(2, a2, 0xffffffff80000000, \
+    li a2, 0xffffffff80000000; \
+    li a3, 0xfffffffffffff800; \
+    la a0, amo_operand; \
+    sw a2, 0(a0); \
+    sw a3, 4(a0); \
+    addi a4, a2, 1; \
+    addi a5, a3, 0; \
+    .word 0x28e5362f;\
+    #amocas.d	a2, a4, 0(a0); \
+  )
+
+  TEST_CASE(3, a5, 0xfffffffffffff800, mv a5, a3)
+  TEST_CASE(4, a5, 0xffffffff80000001, lw a5, 0(a0))
+  TEST_CASE(5, a5, 0xfffffffffffff800, lw a5, 4(a0))
+
+  # try again after a cache miss
+  TEST_CASE(6, a2, 0xffffffff80000001, \
+    addi a2, a2, 1; \
+    addi a4, a4, 1; \
+    .word 0x28e5362f;\
+    #amocas.d a2, a4, 0(a0); \
+  )
+  TEST_CASE(7, a5, 0xfffffffffffff800, mv a5, a3)
+  TEST_CASE(8, a5, 0xffffffff80000002, lw a5, 0(a0))
+  TEST_CASE(9, a5, 0xfffffffffffff800, lw a5, 4(a0))
+
+  # try a cas mismatch
+  TEST_CASE(10, a2, 0xffffffff80000001, \
+    addi a4, a4, 1; \
+    .word 0x28e5362f;\
+    #amocas.d a2, a4, 0(a0); \
+  )
+
+  TEST_CASE(11, a5, 0xfffffffffffff800, mv a5, a3)
+  TEST_CASE(12, a5, 0xffffffff80000002, lw a5, 0(a0))
+  TEST_CASE(13, a5, 0xfffffffffffff800, lw a5, 4(a0))
+
+  # Zero rs2 means zero.
+  TEST_CASE(14, a4, 0x80000000, \
+    li x1, 0x1; \
+    li a2, 0x80000000; \
+    li a3, 0x70000000; \
+    la a0, amo_operand; \
+    sw a2, 0(a0); \
+    sw a3, 4(a0); \
+    .word 0x2805362f;\
+    #amocas.d a2, zero, 0(a0); \
+  )
+  TEST_CASE(15, a7, 0, lw a7, 0(a0))
+  TEST_CASE(16, a7, 0, lw a7, 4(a0))
+
+  # Zero rd means zero
+  TEST_CASE(18, x1, 1, \
+    li x1, 1; \
+    li a4, 0xfffff800; \
+    li a5, 0xfffff700; \
+    la a0, amo_operand; \
+    sw x0, 0(a0); \
+    sw x0, 4(a0); \
+    .word 0x28e5302f;\
+    #amocas.d zero, a4, 0(a0); \
+  )
+  TEST_CASE(19, a7, 0xfffff800, lw a7, 0(a0))
+  TEST_CASE(20, a7, 0xfffff700, lw a7, 4(a0))
+
+#ifndef _ENV_VIRTUAL_SINGLE_CORE_H
+  # only even registers can be encoded in rd pair
+  TEST_CASE(21, x0, x0, \
+    .word 0x28e530af; \
+    #amocas.d x1, a4, 0(a0); \
+  )
+
+  # only even registers can be encoded in rs2 pair
+  TEST_CASE(22, x0, x0, \
+    .word 0x2815302f; \
+    #amocas.d zero, x1, 0(a0); \
+  )
+#endif
+
+  TEST_PASSFAIL
+
+#ifndef _ENV_VIRTUAL_SINGLE_CORE_H
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  # only test 21 and 22 expected to cause an illegal-inst
+  li t1, CAUSE_ILLEGAL_INSTRUCTION
+  csrr t0, mcause
+  bne t0, t1, unexpected
+  li t0, 21
+  beq TESTNUM, t0, expected
+  li t0, 22
+  beq TESTNUM, t0, expected
+unexpected:
+  la t0, fail
+  csrw mepc, t0
+  mret
+expected:
+  csrr t0, mepc
+  addi t0, t0, 4
+  csrw mepc, t0
+  mret
+#endif
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END
+
+  .bss
+  .align 3
+amo_operand:
+  .dword 0
+  .dword 0

--- a/src/asmtest/isa/rv32ua/amocas_w.S
+++ b/src/asmtest/isa/rv32ua/amocas_w.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64U
+#define RVTEST_RV64U RVTEST_RV32U
+
+#include "../rv64ua/amocas_w.S"

--- a/src/asmtest/isa/rv64ua/Makefrag
+++ b/src/asmtest/isa/rv64ua/Makefrag
@@ -3,9 +3,9 @@
 #-----------------------------------------------------------------------
 
 rv64ua_sc_tests = \
-	amoadd_d amoand_d amomax_d amomaxu_d amomin_d amominu_d amoor_d amoxor_d amoswap_d \
-	amoadd_w amoand_w amomax_w amomaxu_w amomin_w amominu_w amoor_w amoxor_w amoswap_w \
-	lrsc \
+	amoadd_d amoand_d amocas_d amomax_d amomaxu_d amomin_d amominu_d amoor_d amoxor_d amoswap_d \
+	amoadd_w amoand_w amocas_w amomax_w amomaxu_w amomin_w amominu_w amoor_w amoxor_w amoswap_w \
+	amocas_q lrsc \
 
 rv64ua_p_tests = $(addprefix rv64ua-p-, $(rv64ua_sc_tests))
 rv64ua_v_tests = $(addprefix rv64ua-v-, $(rv64ua_sc_tests))

--- a/src/asmtest/isa/rv64ua/amocas_d.S
+++ b/src/asmtest/isa/rv64ua/amocas_d.S
@@ -1,0 +1,66 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# amocas_d.S
+#-----------------------------------------------------------------------------
+#
+# Test amocas.d instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(2, a4, 0xffffffff80000000, \
+    li a0, 0xffffffff80000000; \
+    li a1, 0xfffffffffffff800; \
+    la a3, amo_operand; \
+    sd a0, 0(a3); \
+    mv a4, a0; \
+    .word 0x28b6b72f;\
+    #amocas.d	a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(3, a5, 0xffffffff80000000, mv a5, a4)
+  TEST_CASE(4, a5, 0xfffffffffffff800, ld a5, 0(a3))
+
+  # try again after a cache miss
+  TEST_CASE(5, a4, 0xfffffffffffff800, \
+    li  a1, 0xffffffff80000000; \
+    li  a4, 0xfffffffffffff800; \
+    .word 0x28b6b72f;\
+    #amocas.d a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(6, a5, 0xfffffffffffff800, mv a5, a4)
+  TEST_CASE(7, a5, 0xffffffff80000000, ld a5, 0(a3))
+
+  # try a cas mismatch
+  TEST_CASE(8, a4, 0xfffffffffffff800, \
+    li a1, 0xfffffffffffff800; \
+    li a4, 0xfffffffff8000001; \
+    .word 0x28b6b72f;\
+    #amocas.d a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(9, a5, 0xffffffff80000000, mv a5, a4)
+  TEST_CASE(10, a5, 0xffffffff80000000, ld a5, 0(a3))
+
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END
+
+  .bss
+  .align 3
+amo_operand:
+  .dword 0

--- a/src/asmtest/isa/rv64ua/amocas_q.S
+++ b/src/asmtest/isa/rv64ua/amocas_q.S
@@ -1,0 +1,134 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# amocas_q.S
+#-----------------------------------------------------------------------------
+#
+# Test amocas.q instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(2, a2, 0xffffffff80000000, \
+    li a2, 0xffffffff80000000; \
+    li a3, 0xfffffffffffff800; \
+    la a0, amo_operand; \
+    sd a2, 0(a0); \
+    sd a3, 8(a0); \
+    addi a4, a2, 1; \
+    addi a5, a3, 0; \
+    .word 0x28e5462f;\
+    #amocas.q	a2, a4, 0(a0); \
+  )
+
+  TEST_CASE(3, a5, 0xfffffffffffff800, mv a5, a3)
+  TEST_CASE(4, a5, 0xffffffff80000001, ld a5, 0(a0))
+  TEST_CASE(5, a5, 0xfffffffffffff800, ld a5, 8(a0))
+
+  # try again after a cache miss
+  TEST_CASE(6, a2, 0xffffffff80000001, \
+    addi a2, a2, 1; \
+    addi a4, a4, 1; \
+    .word 0x28e5462f;\
+    #amocas.q a2, a4, 0(a0); \
+  )
+  TEST_CASE(7, a5, 0xfffffffffffff800, mv a5, a3)
+  TEST_CASE(8, a5, 0xffffffff80000002, ld a5, 0(a0))
+  TEST_CASE(9, a5, 0xfffffffffffff800, ld a5, 8(a0))
+
+  # try a cas mismatch
+  TEST_CASE(10, a2, 0xffffffff80000001, \
+    addi a4, a4, 1; \
+    .word 0x28e5462f;\
+    #amocas.q a2, a4, 0(a0); \
+  )
+
+  TEST_CASE(11, a5, 0xfffffffffffff800, mv a5, a3)
+  TEST_CASE(12, a5, 0xffffffff80000002, ld a5, 0(a0))
+  TEST_CASE(13, a5, 0xfffffffffffff800, ld a5, 8(a0))
+
+  # Zero rs2 means zero.
+  TEST_CASE(14, a4, 0x80000000, \
+    li x1, 0x1; \
+    li a2, 0xffffffff80000000; \
+    li a3, 0xffffffff70000000; \
+    la a0, amo_operand; \
+    sd a2, 0(a0); \
+    sd a3, 8(a0); \
+    .word 0x2805462f;\
+    #amocas.q a2, zero, 0(a0); \
+  )
+  TEST_CASE(15, a7, 0, ld a7, 0(a0))
+  TEST_CASE(16, a7, 0, ld a7, 8(a0))
+
+  # Zero rd means zero
+  TEST_CASE(18, x1, 1, \
+    li x1, 1; \
+    li a4, 0xfffffffffffff800; \
+    li a5, 0xfffffffffffff700; \
+    la a0, amo_operand; \
+    sd x0, 0(a0); \
+    sd x0, 8(a0); \
+    .word 0x28e5402f;\
+    #amocas.q zero, a4, 0(a0); \
+  )
+  TEST_CASE(19, a7, 0xfffffffffffff800, ld a7, 0(a0))
+  TEST_CASE(20, a7, 0xfffffffffffff700, ld a7, 8(a0))
+
+#ifndef _ENV_VIRTUAL_SINGLE_CORE_H
+  # only even registers can be encoded in rd pair
+  TEST_CASE(21, x0, x0, \
+    .word 0x28e540af; \
+    #amocas.q x1, a4, 0(a0); \
+  )
+
+  # only even registers can be encoded in rs2 pair
+  TEST_CASE(22, x0, x0, \
+    .word 0x2815402f; \
+    #amocas.q zero, x1, 0(a0); \
+  )
+#endif
+
+  TEST_PASSFAIL
+
+#ifndef _ENV_VIRTUAL_SINGLE_CORE_H
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  # only test 21 and 22 expected to cause an illegal-inst
+  li t1, CAUSE_ILLEGAL_INSTRUCTION
+  csrr t0, mcause
+  bne t0, t1, unexpected
+  li t0, 21
+  beq TESTNUM, t0, expected
+  li t0, 22
+  beq TESTNUM, t0, expected
+unexpected:
+  la t0, fail
+  csrw mepc, t0
+  mret
+expected:
+  csrr t0, mepc
+  addi t0, t0, 4
+  csrw mepc, t0
+  mret
+#endif
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END
+
+  .bss
+  .align 3
+amo_operand:
+  .dword 0
+  .dword 0

--- a/src/asmtest/isa/rv64ua/amocas_w.S
+++ b/src/asmtest/isa/rv64ua/amocas_w.S
@@ -1,0 +1,66 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# amocas_w.S
+#-----------------------------------------------------------------------------
+#
+# Test amocas.w instruction.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64U
+RVTEST_CODE_BEGIN
+
+  TEST_CASE(2, a4, 0xffffffff80000000, \
+    li a0, 0xffffffff80000000; \
+    li a1, 0xfffffffffffff800; \
+    la a3, amo_operand; \
+    sw a0, 0(a3); \
+    mv a4, a0; \
+    .word 0x28b6a72f;\
+    #amocas.w	a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(3, a5, 0xffffffff80000000, mv a5, a4)
+  TEST_CASE(4, a5, 0xfffffffffffff800, lw a5, 0(a3))
+
+  # try again after a cache miss
+  TEST_CASE(5, a4, 0xfffffffffffff800, \
+    li  a1, 0xffffffff80000000; \
+    li  a4, 0xfffffffffffff800; \
+    .word 0x28b6a72f;\
+    #amocas.w a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(6, a5, 0xfffffffffffff800, mv a5, a4)
+  TEST_CASE(7, a5, 0xffffffff80000000, lw a5, 0(a3))
+
+  # try a cas mismatch
+  TEST_CASE(8, a4, 0xfffffffffffff800, \
+    li a1, 0xfffffffffffff800; \
+    li a4, 0xfffffffff8000001; \
+    .word 0x28b6a72f;\
+    #amocas.w a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(9, a5, 0xffffffff80000000, mv a5, a4)
+  TEST_CASE(10, a5, 0xffffffff80000000, lw a5, 0(a3))
+
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END
+
+  .bss
+  .align 3
+amo_operand:
+  .dword 0


### PR DESCRIPTION
This PR is based on [RISC-V tests PR 492](https://github.com/riscv-software-src/riscv-tests/pull/492). It adds tests for the Zacas extension. The new tests cover amocas_w and amocas_d for RV32 and amocas_w, amocas_d, and amocas_q for RV64.